### PR TITLE
Protean RSP logs - resubmission

### DIFF
--- a/logs/protean-rsp/COLLECTOR_RECON.json
+++ b/logs/protean-rsp/COLLECTOR_RECON.json
@@ -1,103 +1,102 @@
 {
-    "context": {
-        "transaction_id": "775935779363027100",
-        "country": "IND",
-        "bpp_id": "rsp.proteantech.in",
-        "city": "*",
-        "message_id": "9ea444dc-0643-49a9-a01b-41858b27776e",
-        "core_version": "1.0.0",
-        "ttl": "P2D",
-        "bap_id": "cloud-adaptor.proteantech.in/kotak",
-        "domain": "nic2004:12345",
-        "bpp_uri": "https://rsp.proteantech.in",
-        "action": "collector_recon",
-        "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
-        "key": null,
-        "timestamp": "2022-12-23T10:34:58.469Z"
-    },
-    "message": {
-        "orderbook": {
-            "orders": [
-                {
-                    "withholding_tax_gst": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "receiver_app_uri": "https://ondcmp.nlincs.in/bpp",
-                    "invoice_no": "INV106403902112759",
-                    "created_at": "2022-12-23T10:34:58.469Z",
-                    "deduction_by_collector": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "receiver_app_id": "ondcmp.nlincs.in",
-                    "settlement_reason_code": "01",
-                    "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-                    "updated_at": "2022-12-23T10:34:58.469Z",
-                    "provider": {
-                        "address": "NewDelhi",
-                        "name": {
-                            "code": "storeCode",
-                            "name": "NSTORE TECHNOLOGIES PRIVATE LIMITED"
-                        }
-                    },
-                    "payerdetails": {
-                        "payer_bank_code": "KKBK0000958",
-                        "payer_name": "ONDC Buyer Pool Account",
-                        "payer_virtual_payment_address": "",
-                        "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
-                        "payer_account_no": 6410125397001
-                    },
-                    "payment": {
-                        "@ondc/org/settlement_window_status": "Assert",
-                        "@ondc/org/buyer_app_finder_fee_type": "Percent",
-                        "collected_by": "BAP",
-                        "params": {
-                            "transaction_id": "12667271",
-                            "amount": "1270.00",
-                            "transaction_status": "PAID",
-                            "currency": "INR"
-                        },
-                        "type": "ON_ORDER",
-                        "@ondc/org/settlement_basis_status": "Assert",
-                        "uri": null,
-                        "@ondc/org/settlement_details": [
-                            {
-                                "beneficiary_address": "Dhampur Green",
-                                "settlement_status": "READY",
-                                "settlement_ifsc_code": "ICIC0000212",
-                                "branch_name": "CHENNAI - SANTHOME",
-                                "settlement_counterparty": "buyer-app",
-                                "settlement_phase": "sale-amount",
-                                "bank_name": "ICICI BANK LTD",
-                                "settlement_amount": 1270,
-                                "settlement_reference": "3122637",
-                                "settlement_timestamp": "2022-12-22T10:34:58.469Z",
-                                "settlement_bank_account_no": "021205008922",
-                                "upi_address": null,
-                                "settlement_type": "NEFT"
-                            }
-                        ],
-                        "@ondc/org/return_window": "0",
-                        "@ondc/org/settlement_window": "P2D",
-                        "@ondc/org/settlement_basis": "Collection",
-                        "@ondc/org/withholding_amount_status": "Assert",
-                        "@ondc/org/return_window_status": "Assert",
-                        "@ondc/org/withholding_amount": "0.0",
-                        "time": null,
-                        "@ondc/org/collected_by_status": "Assert",
-                        "tl_method": "HTTP_OR_GET",
-                        "status": "PAID",
-                        "@ondc/org/buyer_app_finder_fee_amount": "0"
-                    },
-                    "id": "K8c347ae1",
-                    "state": "Completed",
-                    "withholding_tax_tds": {
-                        "currency": "INR",
-                        "value": "0"
-                    }
-                }
-            ]
+  "context": {
+    "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
+    "country": "IND",
+    "bpp_id": "rsp.proteantech.in",
+    "city": "*",
+    "message_id": "9ea444dc-0643-49a9-a01b-41858b27776e",
+    "core_version": "1.0.0",
+    "ttl": "P2D",
+    "bap_id": "cloud-adaptor.proteantech.in/kotak",
+    "domain": "nic2004:12345",
+    "bpp_uri": "https://rsp.proteantech.in",
+    "action": "collector_recon",
+    "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
+    "key": null,
+    "timestamp": "2023-01-12T12:30:01.469Z"
+  },
+  "message": {
+    "orderbook": {
+      "orders": [
+        {
+          "withholding_tax_gst": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "receiver_app_uri": "https://ondcmp.nlincs.in/bpp",
+          "invoice_no": "INV222405902117800",
+          "created_at": "2023-01-12T12:30:01.469Z",
+          "deduction_by_collector": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "settlement_reason_code": "01",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "updated_at": "2023-01-12T12:30:01.469Z",
+          "provider": {
+            "address": "NewDelhi",
+            "name": {
+              "code": "storeCode",
+              "name": "NSTORE TECHNOLOGIES PRIVATE LIMITED"
+            }
+          },
+          "payerdetails": {
+            "payer_bank_code": "KKBK0000958",
+            "payer_name": "ONDC Buyer Pool Account",
+            "payer_virtual_payment_address": "",
+            "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
+            "payer_account_no": 6410125397001
+          },
+          "payment": {
+            "@ondc/org/settlement_window_status": "Assert",
+            "@ondc/org/buyer_app_finder_fee_type": "Percent",
+            "collected_by": "BAP",
+            "params": {
+              "transaction_id": "24001267",
+              "amount": "1270.00",
+              "transaction_status": "PAID",
+              "currency": "INR"
+            },
+            "type": "ON_ORDER",
+            "@ondc/org/settlement_basis_status": "Assert",
+            "uri": null,
+            "@ondc/org/settlement_details": [
+              {
+                "beneficiary_address": "Dhampur Green",
+                "settlement_status": "READY",
+                "settlement_ifsc_code": "ICIC0000212",
+                "branch_name": "CHENNAI - SANTHOME",
+                "settlement_counterparty": "buyer-app",
+                "settlement_phase": "sale-amount",
+                "bank_name": "ICICI BANK LTD",
+                "settlement_amount": 1270,
+                "settlement_reference": "3122637",
+                "settlement_timestamp": "2023-01-12T12:30:01.469Z",
+                "settlement_bank_account_no": "021205008922",
+                "upi_address": null,
+                "settlement_type": "NEFT"
+              }
+            ],
+            "@ondc/org/return_window": "0",
+            "@ondc/org/settlement_window": "P2D",
+            "@ondc/org/settlement_basis": "Collection",
+            "@ondc/org/withholding_amount_status": "Assert",
+            "@ondc/org/return_window_status": "Assert",
+            "@ondc/org/withholding_amount": "0.0",
+            "time": null,
+            "@ondc/org/collected_by_status": "Assert",
+            "status": "PAID",
+            "@ondc/org/buyer_app_finder_fee_amount": "0"
+          },
+          "id": "ghc11af11",
+          "state": "Completed",
+          "withholding_tax_tds": {
+            "currency": "INR",
+            "value": "0"
+          }
         }
+      ]
     }
+  }
 }

--- a/logs/protean-rsp/ONCOLLECTOR_RECON.json
+++ b/logs/protean-rsp/ONCOLLECTOR_RECON.json
@@ -1,50 +1,50 @@
 {
-    "context": {
-        "transaction_id": "e621a69c-e25c-4d5f-a474-a02d12a29f6f",
-        "country": "IND",
-        "bpp_id": "rsp.proteantech.in",
-        "city": "*",
-        "message_id": "00e92b2f-c21b-4f71-af53-ad7912b8056f",
-        "core_version": "1.0.0",
-        "ttl": "P2D",
-        "bap_id": "cloud-adaptor.proteantech.in/kotak",
-        "domain": "nic2004:12345",
-        "bpp_uri": "https://rsp.proteantech.in",
-        "action": "on_collector_recon",
-        "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
-        "key": null,
-        "timestamp": "2022-12-23T10:38:58.469Z"
-    },
-    "message": {
-        "orderbook": {
-            "order": [
-                {
-                    "transaction_id": "775935779363027100",
-                    "settlement_id": "d3001107-3029-40db-9ca4-d532a6a02ffd",
-                    "counterparty_diff_amount": {
-                        "currency": "INR",
-                        "value": "20"
-                    },
-                    "counterparty_recon_status": "03",
-                    "invoice_no": "INV106403902112759",
-                    "created_at": "2022-12-23T10:38:58.469Z",
-                    "diff_amount": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "recon_status": "01",
-                    "message": {
-                        "code": "less",
-                        "name": "lesser amount"
-                    },
-                    "order_recon_status": "01",
-                    "receiver_app_id": "ondcmp.nlincs.in",
-                    "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-                    "updated_at": "2022-12-23T10:38:58.469Z",
-                    "id": "K8c347ae1",
-                    "settlement_reference_no": "KB012334FH"
-                }
-            ]
+  "context": {
+    "transaction_id": "fc9c7f85-dbc3-40af-9913-628c7be9ecee",
+    "country": "IND",
+    "bpp_id": "rsp.proteantech.in",
+    "city": "*",
+    "message_id": "2731405b-2072-4c09-8d3c-6667e9341a1a",
+    "core_version": "1.0.0",
+    "ttl": "P2D",
+    "bap_id": "cloud-adaptor.proteantech.in/kotak",
+    "domain": "nic2004:12345",
+    "bpp_uri": "https://rsp.proteantech.in",
+    "action": "on_collector_recon",
+    "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
+    "key": null,
+    "timestamp": "2023-01-12T12:38:02.001Z"
+  },
+  "message": {
+    "orderbook": {
+      "order": [
+        {
+          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
+          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "counterparty_diff_amount": {
+            "currency": "INR",
+            "value": "20"
+          },
+          "counterparty_recon_status": "03",
+          "invoice_no": "INV222405902117800",
+          "created_at": "2023-01-12T12:38:02.001Z",
+           "diff_amount": {	
+            "currency": "INR",	
+            "value": "0"	
+          },
+          "recon_status": "01",
+          "message": {
+            "code": "less",
+            "name": "lesser amount"
+          },
+          "order_recon_status": "01",
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "updated_at": "2023-01-12T12:38:02.001Z",
+          "id": "ghc11af11",
+          "settlement_reference_no": "KC356687GK"
         }
+      ]
     }
+  }
 }

--- a/logs/protean-rsp/ONRECEIVER_RECON.json
+++ b/logs/protean-rsp/ONRECEIVER_RECON.json
@@ -1,50 +1,50 @@
 {
-    "context": {
-        "domain": "nic2004:12345",
-        "country": "IND",
-        "city": "*",
-        "action": "on_receiver_recon",
-        "core_version": "1.0.0",
-        "bap_id": "rsp.proteantech.in",
-        "bap_uri": "https://rsp.proteantech.in",
-        "bpp_id": "ondcmp.nlincs.in",
-        "bpp_uri": "https://ondcmp.nlincs.in/bpp",
-        "transaction_id": "775935779363027100",
-        "message_id": "9ea444dc-0643-49a9-a01b-41858b27776e",
-        "timestamp": "2022-12-23T10:37:58.469Z",
-        "key": null,
-        "ttl": "P2D"
-    },
-    "message": {
-        "orderbook": {
-            "orders": [
-                {
-                    "id": "K8c347ae1",
-                    "invoice_no": "INV106403902112759",
-                    "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-                    "receiver_app_id": "ondcmp.nlincs.in",
-                    "order_recon_status": "01",
-                    "transaction_id": "775935779363027100",
-                    "settlement_id": "d3001107-3029-40db-9ca4-d532a6a02ffd",
-                    "settlement_reference_no": "KB012334FH",
-                    "recon_status": "01",
-                    "counterparty_recon_status": "03",
-                    "counterparty_diff_amount": {
-                        "currency": "INR",
-                        "value": "20"
-                    },
-                    "message": {
-                        "name": "lesser amount",
-                        "code": "less"
-                    },
-                    "created_at": "2022-12-23T10:37:58.469Z",
-                    "updated_at": "2022-12-23T10:37:58.469Z",
-                    "diff_amount": {
-                        "currency": "INR",
-                        "value": "0"
-                    }
-                }
-            ]
+  "context": {
+    "domain": "nic2004:12345",
+    "country": "IND",
+    "city": "*",
+    "action": "on_receiver_recon",
+    "core_version": "1.0.0",
+    "bap_id": "rsp.proteantech.in",
+    "bap_uri": "https://rsp.proteantech.in",
+    "bpp_id": "ondcmp.nlincs.in",
+    "bpp_uri": "https://ondcmp.nlincs.in/bpp",
+    "transaction_id": "7asa911a-6cbe-4ad3-94e9-acb96aaff432",
+    "message_id": "22aa811a-61be-55d3-99e9-cbf12abff347",
+    "timestamp": "2023-01-12T12:37:11.121Z",
+    "key": null,
+    "ttl": "P2D"
+  },
+  "message": {
+    "orderbook": {
+      "orders": [
+        {
+          "id": "ghc11af11",
+          "invoice_no": "INV222405902117800",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "order_recon_status": "01",
+          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
+          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "settlement_reference_no": "KC356687GK",
+          "recon_status": "01",
+          "counterparty_recon_status": "03",
+          "counterparty_diff_amount": {
+            "currency": "INR",
+            "value": "20"
+          },
+          "message": {
+            "name": "lesser amount",
+            "code": "less"
+          },
+          "created_at": "2023-01-12T12:37:11.121Z",
+          "updated_at": "2023-01-12T12:37:11.121Z",
+          "diff_amount": {
+            "currency": "INR",
+            "value": "0"
+          }
         }
+      ]
     }
+  }
 }

--- a/logs/protean-rsp/ON_SETTLE.json
+++ b/logs/protean-rsp/ON_SETTLE.json
@@ -1,36 +1,36 @@
 {
-    "context": {
-        "domain": "nic2004:12345",
-        "country": "IND",
-        "city": "*",
-        "action": "on_settle",
-        "core_version": "1.0.0",
-        "bap_id": "rsp.proteantech.in",
-        "bap_uri": "https://rsp.proteantech.in",
-        "bpp_id": "formatter.proteantech.in",
-        "bpp_uri": "http://formatter.proteantech.in",
-        "transaction_id": "c197a2f2-6195-41ed-b945-5f70b1673b1d",
-        "message_id": "e1ee65c6-aca9-4b9f-8287-e089acf07420",
-        "timestamp": "2022-12-23T10:35:30.469Z",
-        "key": null,
-        "ttl": "P2D"
-    },
-    "message": {
-        "settlement": {
-            "settlements": [
-                {
-                    "curr_type": "INR",
-                    "amount": {
-                        "currency": "INR",
-                        "value": "1270.0"
-                    },
-                    "settlement_id": "d3001107-3029-40db-9ca4-d532a6a02ffd",
-                    "state": "01",
-                    "settlement_reference_no": "KB012334FH",
-                    "error_code": "",
-                    "error_message": ""
-                }
-            ]
+  "context": {
+    "domain": "nic2004:12345",
+    "country": "IND",
+    "city": "*",
+    "action": "on_settle",
+    "core_version": "1.0.0",
+    "bap_id": "rsp.proteantech.in",
+    "bap_uri": "https://rsp.proteantech.in",
+    "bpp_id": "formatter.proteantech.in",
+    "bpp_uri": "http://formatter.proteantech.in",
+    "transaction_id": "b2d206ad-b1a0-4de3-85cb-f4988832ae52",
+    "message_id": "7274e08b-7188-446e-bd23-2b3c800853ff",
+    "timestamp": "2023-01-12T12:36:00.008Z",
+    "key": null,
+    "ttl": "P2D"
+  },
+  "message": {
+    "settlement": {
+      "settlements": [
+        {
+          "curr_type": "INR",
+          "amount": {
+            "currency": "INR",
+            "value": "1270.0"
+          },
+          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "state": "01",
+          "settlement_reference_no": "KC356687GK",
+          "error_code": "",
+          "error_message": ""
         }
+      ]
     }
+  }
 }

--- a/logs/protean-rsp/RECEIVER_RECON.json
+++ b/logs/protean-rsp/RECEIVER_RECON.json
@@ -1,115 +1,114 @@
 {
-    "context": {
-        "transaction_id": "733027fd-c7e2-4c24-9dfa-bba61acd84c4",
-        "country": "IND",
-        "bpp_id": "ondcmp.nlincs.in",
-        "city": "*",
-        "message_id": "b68db2dd-1c2a-4d22-86d2-5d91b7284b3c",
-        "core_version": "1.0.0",
-        "ttl": "P2D",
-        "bap_id": "rsp.proteantech.in",
-        "domain": "nic2004:12345",
-        "bpp_uri": "https://ondcmp.nlincs.in/bpp",
-        "action": "receiver_recon",
-        "bap_uri": "https://rsp.proteantech.in",
-        "key": null,
-        "timestamp": "2022-12-23T10:36:58.469Z"
-    },
-    "message": {
-        "orderbook": {
-            "orders": [
-                {
-                    "payerDetails": {
-                        "payer_bank_code": "KKBK0000958",
-                        "payer_name": "ONDC Buyer Pool Account",
-                        "payer_virtual_payment_address": "",
-                        "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
-                        "payer_account_no": 2034191369
-                    },
-                    "transaction_id": "775935779363027100",
-                    "withholding_tax_gst": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "settlement_id": "d3001107-3029-40db-9ca4-d532a6a02ffd",
-                    "invoice_no": "INV106403902112759",
-                    "created_at": "2022-12-23T10:36:58.469Z",
-                    "diff_amount": {
-                        "currency": null,
-                        "value": null
-                    },
-                    "recon_status": "01",
-                    "message": {
-                        "code": null,
-                        "name": null
-                    },
-                    "order_recon_status": null,
-                    "deduction_by_collector": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "receiver_app_id": "ondcmp.nlincs.in",
-                    "settlement_reason_code": "01",
-                    "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-                    "updated_at": "2022-12-23T10:36:58.469Z",
-                    "provider": {
-                        "address": "NewDelhi",
-                        "name": {
-                            "code": "storeCode",
-                            "name": "NSTORE TECHNOLOGIES PRIVATE LIMITED"
-                        }
-                    },
-                    "payment": {
-                        "@ondc/org/settlement_window_status": "Assert",
-                        "@ondc/org/buyer_app_finder_fee_type": "Percent",
-                        "collected_by": "BAP",
-                        "params": {
-                            "transaction_id": "12667271",
-                            "amount": "1270.00",
-                            "transaction_status": "PAID",
-                            "currency": "INR"
-                        },
-                        "type": "ON_ORDER",
-                        "@ondc/org/settlement_basis_status": "Assert",
-                        "uri": null,
-                        "@ondc/org/settlement_details": [
-                            {
-                                "beneficiary_address": "Dhampur Green",
-                                "settlement_status": "PAID",
-                                "settlement_ifsc_code": "ICIC0000212",
-                                "settlement_counterparty": "buyer-app",
-                                "settlement_phase": "sale-amount",
-                                "branch_name": "CHENNAI - SANTHOME",
-                                "bank_name": "ICICI BANK LTD",
-                                "settlement_amount": 1270,
-                                "settlement_reference": "KB012334FH",
-                                "settlement_timestamp": "2022-12-22T00:00:00.000Z",
-                                "settlement_bank_account_no": "021205008922",
-                                "upi_address": null,
-                                "settlement_type": "NEFT"
-                            }
-                        ],
-                        "@ondc/org/return_window": "0",
-                        "@ondc/org/settlement_window": "P2D",
-                        "@ondc/org/settlement_basis": "Collection",
-                        "@ondc/org/withholding_amount_status": "Assert",
-                        "@ondc/org/return_window_status": "Assert",
-                        "@ondc/org/withholding_amount": "0.0",
-                        "@ondc/org/collected_by_status": "Assert",
-                        "status": "PAID",
-                        "tl_method": "HTTP_OR_GET",
-                        "@ondc/org/buyer_app_finder_fee_amount": "0"
-                    },
-                    "id": "K8c347ae1",
-                    "state": "Completed",
-                    "settlement_reference_no": "KB012334FH",
-                    "withholding_tax_tds": {
-                        "currency": "INR",
-                        "value": "0"
-                    },
-                    "correction": null
-                }
+  "context": {
+    "domain": "nic2004:12345",
+    "country": "IND",
+    "city": "*",
+    "action": "receiver_recon",
+    "core_version": "1.0.0",
+    "bap_id": "rsp.proteantech.in",
+    "bap_uri": "https://rsp.proteantech.in",
+    "bpp_id": "ondcmp.nlincs.in",
+    "bpp_uri": "https://ondcmp.nlincs.in/bpp",
+    "transaction_id": "9c5e1976-e300-442a-943c-e417fc0d2e54",
+    "message_id": "ac214f77-55e3-4b68-8444-ecc475699a46",
+    "timestamp": "2023-01-12T12:36:10.022Z",
+    "key": null,
+    "ttl": "P2D"
+  },
+  "message": {
+    "orderbook": {
+      "orders": [
+        {
+          "id": "ghc11af11",
+          "invoice_no": "INV222405902117800",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "order_recon_status": null,
+          "state": "Completed",
+          "provider": {
+            "name": {
+              "name": "NSTORE TECHNOLOGIES PRIVATE LIMITED",
+              "code": "storeCode"
+            },
+            "address": "NewDelhi"
+          },
+          "payment": {
+            "uri": null,
+            "params": {
+              "transaction_id": "24001267",
+              "currency": "INR",
+              "amount": "1270.00",
+              "transaction_status": "PAID"
+            },
+            "type": "ON_ORDER",
+            "status": "PAID",
+            "collected_by": "BAP",
+            "@ondc/org/collected_by_status": "Assert",
+            "@ondc/org/buyer_app_finder_fee_type": "Percent",
+            "@ondc/org/buyer_app_finder_fee_amount": "0",
+            "@ondc/org/withholding_amount": "0.0",
+            "@ondc/org/withholding_amount_status": "Assert",
+            "@ondc/org/return_window": "0",
+            "@ondc/org/return_window_status": "Assert",
+            "@ondc/org/settlement_basis": "Collection",
+            "@ondc/org/settlement_basis_status": "Assert",
+            "@ondc/org/settlement_window": "P2D",
+            "@ondc/org/settlement_window_status": "Assert",
+            "@ondc/org/settlement_details": [
+              {
+                "settlement_counterparty": "buyer-app",
+                "settlement_phase": "sale-amount",
+                "settlement_amount": 1270,
+                "settlement_type": "NEFT",
+                "settlement_bank_account_no": "021205008922",
+                "settlement_ifsc_code": "ICIC0000212",
+                "upi_address": null,
+                "bank_name": "ICICI BANK LTD",
+                "branch_name": "CHENNAI - SANTHOME",
+                "beneficiary_address": "Dhampur Green",
+                "settlement_status": "PAID",
+                "settlement_reference": "KC356687GK",
+                "settlement_timestamp": "2023-01-12T12:36:10.022Z"
+              }
             ]
+          },
+          "withholding_tax_gst": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "withholding_tax_tds": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "deduction_by_collector": {
+            "currency": "INR",
+            "value": "0"
+          },
+          "payerDetails": {
+            "payer_name": "ONDC Buyer Pool Account",
+            "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
+            "payer_account_no": 2034191369,
+            "payer_bank_code": "KKBK0000958",
+            "payer_virtual_payment_address": ""
+          },
+          "settlement_reason_code": "01",
+          "correction": null,
+          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
+          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "settlement_reference_no": "KC356687GK",
+          "recon_status": "01",
+          "message": {
+            "name": null,
+            "code": null
+          },
+          "created_at": "2023-01-12T12:36:10.022Z",
+          "updated_at": "2023-01-12T12:36:10.022Z",
+          "diff_amount": {
+            "currency": null,
+            "value": null
+          }
         }
+      ]
     }
+  }
 }

--- a/logs/protean-rsp/SETTLE.json
+++ b/logs/protean-rsp/SETTLE.json
@@ -1,58 +1,57 @@
 {
-    "context": {
-        "transaction_id": "787c0de9-5130-4181-89f3-e87d8e96474c",
-        "country": "IND",
-        "bpp_id": "formatter.proteantech.in",
-        "city": "*",
-        "message_id": "17caea1e-a93e-4424-ba6e-5679b42c05d6",
-        "core_version": "1.0.0",
-        "ttl": "P2D",
-        "bap_id": "rsp.proteantech.in",
-        "domain": "nic2004:52110",
-        "bpp_uri": "http://formatter.proteantech.in",
-        "action": "settle",
-        "bap_uri": "https://rsp.proteantech.in",
-        "key": null,
-        "timestamp": "2022-12-23T10:35:01.469Z"
-    },
-    "message": {
-        "settlement": {
-            "settlements": [
-                {
-                    "payee_account_type": "02",
-                    "settlement_id": "d3001107-3029-40db-9ca4-d532a6a02ffd",
-                    "curr_type": "INR",
-                    "collector_app_id": "cloud-adaptor.proteantech.in\/kotak",
-                    "bank_name": "ICICI BANK LTD",
-                    "purpose_code": "01",
-                    "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
-                    "timestamp": "2022-12-23T10:35:01.469Z",
-                    "payee_bank_code": "ICIC0000212",
-                    "error_message": null,
-                    "amount": {
-                        "currency": "INR",
-                        "value": "1270.0"
-                    },
-                    "payee_address": "Dhampur Green",
-                    "payee_account_no": "021205008922",
-                    "payer_virtual_payment_address": "",
-                    "payee_virtual_payment_address": null,
-                    "prev_settlement_reference_no": [
-                        "KB012334FH"
-                    ],
-                    "payer_account_no": 6410125397001,
-                    "receiver_app_id": "ondcmp.nlincs.in",
-                    "payer_bank_code": "KKBK0000958",
-                    "payment_type": "01",
-                    "payee_name": "NSTORE TECHNOLOGIES PRIVATE LIMITED",
-                    "error_code": null,
-                    "settlement_reference_no": null,
-                    "payer_name": "ONDC Buyer Pool Account",
-                    "remarks": {
-                        "name": null
-                    }
-                }
-            ]
+  "context": {
+    "transaction_id": "b22642a2-6556-4c12-bc00-d5e4dafba729",
+    "country": "IND",
+    "bpp_id": "formatter.proteantech.in",
+    "city": "*",
+    "message_id": "0e45a377-ca37-4a2b-840a-233fc26d2263",
+    "core_version": "1.0.0",
+    "ttl": "P2D",
+    "bap_id": "rsp.proteantech.in",
+    "domain": "nic2004:12345",
+    "bpp_uri": "http://formatter.proteantech.in",
+    "action": "settle",
+    "bap_uri": "https://rsp.proteantech.in",
+    "key": null,
+    "timestamp": "2023-01-12T12:35:11.558Z"
+  },
+  "message": {
+    "settlement": {
+      "settlements": [
+        {
+          "payee_account_type": "02",
+          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "curr_type": "INR",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "bank_name": "ICICI BANK LTD",
+          "purpose_code": "01",
+          "state": "02",
+          "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
+          "timestamp": "2023-01-12T12:35:11.558Z",
+          "payee_bank_code": "ICIC0000212",
+          "error_message": null,
+          "amount": {
+            "currency": "INR",
+            "value": "1270.0"
+          },
+          "payee_address": "Dhampur Green",
+          "payee_account_no": "021205008922",
+          "payer_virtual_payment_address": "",
+          "payee_virtual_payment_address": null,
+          "prev_settlement_reference_no": [],
+          "payer_account_no": 6410125397001,
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "payer_bank_code": "KKBK0000958",
+          "payment_type": "01",
+          "payee_name": "NSTORE TECHNOLOGIES PRIVATE LIMITED",
+          "error_code": null,
+          "settlement_reference_no": null,
+          "payer_name": "ONDC Buyer Pool Account",
+          "remarks": {
+            "name": null
+          }
         }
+      ]
     }
+  }
 }


### PR DESCRIPTION
Corrected the below review comments : 

**/collector_recon**
`a) transaction_id, not UUID. Recommended UUID `
&emsp; _changed to UUID_

**/receiver_recon**
`a) transaction_id of message is not same as in context`
&emsp; _receiver_recon will have a transaction_id with each order object, which is same as the transaction_id of collector_recon for that order. It can have multiple orders which may have multiple collector_recon (with different transaction_id) in them._ 

**/on_collector_recon**
`a) message_id is not same as /collector_recon`
&emsp; _on_collector_recon can have the orders from two different collector_recon, as there is no such restriction, hence message_id cannot be same as of collector_recon._

**/on_receiver_recon**
`a) message_id is not same as /receiver_recon`
&emsp; _on_receiver_recon can have the orders from two different reciever_recon, as there is no such restriction, hence message_id cannot be same as of reciever_recon._

**/settle**
`a) domain is wrong in context`
&emsp; _fixed_
`b) "prev_settlement_reference_no" is populated with settlement reference number which is incorrect`
&emsp; _fixed_

**/on_settle**
`a) message_id is not same as /settle`
&emsp; _on_settle can have status of settlement advice from two different /settle call, as there is no such restriction, hence message_id cannot be same as of settle call_

**General**
`Transaction_id, format is not consistent `
&emsp; _changed to UUID_