### PR TITLE
Nearshop Verification Logs (Review, Comments, & Fixes)

### DIFF
--- a/logs/Nearshop/cancel.json
+++ b/logs/Nearshop/cancel.json
@@ -9,13 +9,13 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "ebc85aa1-14b7-4614-a7d6-f62fd97f6bd0",
-        "message_id": "2dcdb2af-b174-404b-96a4-263d9f1d6971",
-        "timestamp": "2023-01-29T08:02:45.252Z",
+        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
+        "message_id": "b5dd4ef5-0d2d-44d1-903e-c30728f99f96",
+        "timestamp": "2023-01-30T15:45:08.910Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "1d0df8e6-8447-4728-a3bf-7fb91741b120",
+        "order_id": "bb5bc364-5634-42c3-8032-5fe3644d9130",
         "cancellation_reason_id": "001"
     }
 }

--- a/logs/Nearshop/confirm.json
+++ b/logs/Nearshop/confirm.json
@@ -9,14 +9,14 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "ee68f4c4-69b3-401f-8214-7bb11672e76f",
-        "timestamp": "2023-01-29T07:44:35.174Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "80cd8cf1-4633-4ae3-b3c1-83747bf38c5c",
+        "timestamp": "2023-01-30T15:32:52.784Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "5d560431-808d-46ad-b458-c7c6ce87591a",
+            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207",
             "state": "Created",
             "billing": {
                 "address": {
@@ -28,11 +28,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T07:44:35.140Z",
+                "created_at": "2023-01-30T15:32:52.748Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-29T07:44:35.140Z"
+                "updated_at": "2023-01-30T15:32:52.748Z"
             },
             "fulfillments": [
                 {
@@ -107,12 +107,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_L9umrgfCeoJ6Kx"
+                    "transaction_id": "order_LARIftVXGpRvPM"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-29T07:44:35.140Z"
+                    "timestamp": "2023-01-30T15:32:52.748Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -130,8 +130,8 @@
                     }
                 ]
             },
-            "created_at": "2023-01-29T07:44:35.140Z",
-            "updated_at": "2023-01-29T07:44:35.140Z",
+            "created_at": "2023-01-30T15:32:52.748Z",
+            "updated_at": "2023-01-30T15:32:52.748Z",
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [

--- a/logs/Nearshop/init.json
+++ b/logs/Nearshop/init.json
@@ -1,7 +1,7 @@
 {
     "context": {
         "domain": "nic2004:52110",
-        "action": "select",
+        "action": "init",
         "country": "IND",
         "city": "std:080",
         "core_version": "1.0.0",
@@ -9,34 +9,74 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "9516d137-2bf9-4c72-a378-02d4d2688192",
-        "timestamp": "2023-01-29T07:44:14.126Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "7cf90b6b-52a4-4028-9869-598170816df5",
+        "timestamp": "2023-01-30T15:32:41.511Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
+            "billing": {
+                "address": {
+                    "area_code": "560064",
+                    "city": "Bangalore",
+                    "country": "IN",
+                    "door": "ABC Street, ABC",
+                    "locality": "ABC Street, ABC",
+                    "name": "ABC Street, ABC",
+                    "state": "KARNATAKA"
+                },
+                "created_at": "2023-01-30T15:32:41.454Z",
+                "email": "sumitait5219@gmail.com",
+                "name": "SumitKumar",
+                "phone": "9886394142",
+                "tax_number": "",
+                "updated_at": "2023-01-30T15:32:41.454Z"
+            },
             "fulfillments": [
                 {
                     "end": {
+                        "contact": {
+                            "email": "sumitait5219@gmail.com",
+                            "phone": "9886394142"
+                        },
                         "location": {
-                            "gps": "13.0866363,77.6225953",
                             "address": {
-                                "area_code": "560064"
-                            }
+                                "area_code": "560064",
+                                "city": "Bangalore",
+                                "country": "IN",
+                                "door": "-",
+                                "locality": "-",
+                                "name": "ABC Street, ABC",
+                                "state": "KARNATAKA"
+                            },
+                            "gps": "12.9159993,77.6195245"
+                        },
+                        "person": {
+                            "name": "Sumit Kumar"
                         }
-                    }
+                    },
+                    "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
+                    "tracking": true,
+                    "type": "Delivery",
+                    "provider_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7"
                 }
             ],
             "items": [
                 {
                     "id": "fea40eec-fa72-4230-9e5d-40eb606e70db",
-                    "location_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location",
+                    "fulfillment_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                     "quantity": {
                         "count": 2
                     }
                 }
             ],
+            "payment": {
+                "type": "ON-ORDER",
+                "status": "NOT-PAID",
+                "collected_by": "BAP",
+                "@ondc/org/collected_by_status": "Assert"
+            },
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [

--- a/logs/Nearshop/on_cancel.json
+++ b/logs/Nearshop/on_cancel.json
@@ -1,37 +1,34 @@
 {
     "context": {
         "domain": "nic2004:52110",
+        "action": "on_cancel",
         "country": "IND",
         "city": "std:080",
-        "action": "on_status",
         "core_version": "1.0.0",
-        "transaction_id": "0ec37b1c-133b-412b-998e-b453fb18b033",
-        "message_id": "bf81f349-122c-4fa3-b00d-012b5289a919",
-        "timestamp": "2023-01-29T08:02:45.742Z",
         "bpp_id": "api.staging.nearshop.in",
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
-        "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/"
+        "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
+        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
+        "message_id": "b5dd4ef5-0d2d-44d1-903e-c30728f99f96",
+        "timestamp": "2023-01-30T15:45:09.140Z",
+        "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "state": "Accepted",
+            "state": "Cancelled",
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [
                     {
-                        "id": "8b2d2ad1-41ca-55fe-b21b-ba8a86979bd5"
+                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
                     }
                 ]
             },
             "items": [
                 {
-                    "id": "184ac88f-0c41-419d-be32-994879631e18",
+                    "id": "fea40eec-fa72-4230-9e5d-40eb606e70db",
                     "fulfillment_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "price": {
-                        "currency": "INR",
-                        "value": "31"
-                    },
                     "quantity": {
                         "count": 1
                     }
@@ -40,19 +37,28 @@
             "quote": {
                 "price": {
                     "currency": "INR",
-                    "value": "31"
+                    "value": "135"
                 },
                 "breakup": [
                     {
-                        "@ondc/org/item_id": "184ac88f-0c41-419d-be32-994879631e18",
+                        "@ondc/org/item_id": "fea40eec-fa72-4230-9e5d-40eb606e70db",
                         "@ondc/org/item_quantity": {
                             "count": 1
                         },
                         "@ondc/org/title_type": "item",
-                        "title": "Gobi | Cauliflower",
+                        "title": "Watermelon",
                         "price": {
                             "currency": "INR",
-                            "value": "31"
+                            "value": "105"
+                        }
+                    },
+                    {
+                        "@ondc/org/item_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
+                        "title": "Delivery charges",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "30"
                         }
                     }
                 ],
@@ -68,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-16T21:52:40",
+                "created_at": "2023-01-30T15:44:48.929Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-16T21:52:40"
+                "updated_at": "2023-01-30T15:44:48.929Z"
             },
             "fulfillments": [
                 {
@@ -91,7 +97,7 @@
                                 "name": "ABC Street, ABC",
                                 "state": "KARNATAKA"
                             },
-                            "gps": "13.0866363,77.6225953"
+                            "gps": "12.9159993,77.6195245"
                         },
                         "person": {
                             "name": "Sumit Kumar"
@@ -109,19 +115,19 @@
                 }
             ],
             "payment": {
-                "type": "POST-FULFILLMENT",
+                "type": "ON-ORDER",
                 "params": {
-                    "amount": "31",
-                    "currency": "INR"
+                    "amount": "135",
+                    "currency": "INR",
+                    "transaction_id": "order_LARVKyWNagNm4m"
                 },
-                "status": "NOT-PAID",
-                "collected_by": "BPP",
-                "@ondc/org/withholding_amount": "0.0",
-                "@ondc/org/return_window": "0",
+                "status": "PAID",
+                "collected_by": "BAP",
+                "time": {
+                    "timestamp": "2023-01-30T15:44:48.929Z"
+                },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
-                "@ondc/org/settlement_basis": "P2D",
-                "@ondc/org/settlement_window": "P2D",
                 "@ondc/org/settlement_details": [
                     {
                         "settlement_ifsc_code": "UTIB0000234",
@@ -138,8 +144,24 @@
             },
             "addOns": [],
             "offers": [],
-            "documents": [],
-            "id": "c6d59281-9315-4026-b3b1-6a6b0c77c7f0"
+            "documents": [
+                {
+                    "url": "",
+                    "label": ""
+                }
+            ],
+            "created_at": "2023-01-30T15:44:48.929Z",
+            "updated_at": "2023-01-30T15:44:49.168Z",
+            "id": "bb5bc364-5634-42c3-8032-5fe3644d9130",
+            "cancellation": {
+                "cancelled_by": "ondc.indiastack.cloud",
+                "reason": {
+                    "id": "001"
+                }
+            },
+            "tags": {
+                "cancellation_reason_id": "001"
+            }
         }
     }
 }

--- a/logs/Nearshop/on_confirm.json
+++ b/logs/Nearshop/on_confirm.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "ee68f4c4-69b3-401f-8214-7bb11672e76f",
-        "timestamp": "2023-01-29T07:44:35.381Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "80cd8cf1-4633-4ae3-b3c1-83747bf38c5c",
+        "timestamp": "2023-01-30T15:32:53.003Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -21,7 +21,7 @@
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [
                     {
-                        "id": "74493f3c-c027-597f-89f8-a34c781e6e0c"
+                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
                     }
                 ]
             },
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T07:44:35.140Z",
+                "created_at": "2023-01-30T15:32:52.748Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-29T07:44:35.140Z"
+                "updated_at": "2023-01-30T15:32:52.748Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_L9umrgfCeoJ6Kx"
+                    "transaction_id": "order_LARIftVXGpRvPM"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-29T07:44:35.140Z"
+                    "timestamp": "2023-01-30T15:32:52.748Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-29T07:44:35.140Z",
-            "updated_at": "2023-01-29T07:44:35.382Z",
-            "id": "5d560431-808d-46ad-b458-c7c6ce87591a"
+            "created_at": "2023-01-30T15:32:52.748Z",
+            "updated_at": "2023-01-30T15:32:53.003Z",
+            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
         }
     }
 }

--- a/logs/Nearshop/on_init.json
+++ b/logs/Nearshop/on_init.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "22c545ca-14cd-4856-a493-f17e40fb52d3",
-        "timestamp": "2023-01-29T07:44:23.644Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "7cf90b6b-52a4-4028-9869-598170816df5",
+        "timestamp": "2023-01-30T15:32:41.731Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -68,12 +68,12 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T07:44:23.406Z",
+                "created_at": "2023-01-30T15:32:41.454Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
                 "tax_number": "",
-                "updated_at": "2023-01-29T07:44:23.406Z"
+                "updated_at": "2023-01-30T15:32:41.454Z"
             },
             "fulfillments": [
                 {
@@ -114,7 +114,7 @@
                 "collected_by": "BAP",
                 "@ondc/org/collected_by_status": "Agree",
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
-                "@ondc/org/buyer_app_finder_fee_amount": 3,
+                "@ondc/org/buyer_app_finder_fee_amount": "3",
                 "@ondc/org/withholding_amount": "0.0",
                 "@ondc/org/return_window": "0",
                 "@ondc/org/settlement_basis": "Collection",

--- a/logs/Nearshop/on_search.json
+++ b/logs/Nearshop/on_search.json
@@ -7,9 +7,9 @@
 		"core_version": "1.1.0",
 		"bap_id": "ondc.indiastack.cloud",
 		"bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-		"transaction_id": "327aa9aa-f637-4a63-a143-13aae194e2ca",
-		"message_id": "beebd3ad-742a-4d41-aa19-f91cb4face96",
-		"timestamp": "2023-01-29T07:44:02.680Z",
+		"transaction_id": "45da55c3-fc56-4951-a613-b1c839717354",
+		"message_id": "5af81358-6231-4833-bcce-9a8adb1c0325",
+		"timestamp": "2023-01-30T15:32:10.782Z",
 		"ttl": "PT30S",
 		"bpp_id": "api.staging.nearshop.in",
 		"bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1"

--- a/logs/Nearshop/on_select.json
+++ b/logs/Nearshop/on_select.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "9516d137-2bf9-4c72-a378-02d4d2688192",
-        "timestamp": "2023-01-29T07:44:16.006Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "2dcdb2af-b174-404b-96a4-263d9f1d6971",
+        "timestamp": "2023-01-30T15:32:24.272Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/on_status.json
+++ b/logs/Nearshop/on_status.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
         "message_id": "d3ec328a-3e78-4518-88c2-c309c2237c43",
-        "timestamp": "2023-01-29T07:45:03.182Z",
+        "timestamp": "2023-01-30T15:32:58.417Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -21,7 +21,7 @@
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [
                     {
-                        "id": "74493f3c-c027-597f-89f8-a34c781e6e0c"
+                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
                     }
                 ]
             },
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T07:44:35.140Z",
+                "created_at": "2023-01-30T15:32:52.748Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-29T07:44:35.140Z"
+                "updated_at": "2023-01-30T15:32:52.748Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_L9umrgfCeoJ6Kx"
+                    "transaction_id": "order_LARIftVXGpRvPM"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-29T07:44:35.140Z"
+                    "timestamp": "2023-01-30T15:32:52.748Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-29T07:44:35.140Z",
-            "updated_at": "2023-01-29T07:44:35.382Z",
-            "id": "5d560431-808d-46ad-b458-c7c6ce87591a"
+            "created_at": "2023-01-30T15:32:52.748Z",
+            "updated_at": "2023-01-30T15:32:53.003Z",
+            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
         }
     }
 }

--- a/logs/Nearshop/on_support.json
+++ b/logs/Nearshop/on_support.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "f17c74c0-e9e6-4529-8fec-3bfaf68968f1",
-        "timestamp": "2023-01-29T07:44:48.779Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "97ce2075-4837-46fd-913a-8ef4273e4ad9",
+        "timestamp": "2023-01-30T15:33:19.583Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/on_track.json
+++ b/logs/Nearshop/on_track.json
@@ -9,15 +9,15 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "1a60ed36-b2df-448b-bd3d-f2b964490ca6",
-        "timestamp": "2023-01-29T07:44:43.358Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "f47345a7-fdd9-4aee-8851-408fc78c249c",
+        "timestamp": "2023-01-30T15:33:22.797Z",
         "ttl": "PT30S"
     },
     "message": {
         "tracking": {
             "tl_method": "http/get",
-            "url": "https://nearshop.in?order_id=5d560431-808d-46ad-b458-c7c6ce87591a",
+            "url": "https://nearshop.in?order_id=586c7254-02f4-47d0-ab1c-6ec37df13207",
             "status": "active"
         }
     }

--- a/logs/Nearshop/on_update.json
+++ b/logs/Nearshop/on_update.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "de4ea0d9-89b8-4db6-a1df-3e4de1b8f6c5",
-        "timestamp": "2023-01-29T07:46:05.474Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "8a1b82f9-8af0-4182-8715-9e777a5eef63",
+        "timestamp": "2023-01-30T15:33:39.970Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -21,7 +21,7 @@
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [
                     {
-                        "id": "74493f3c-c027-597f-89f8-a34c781e6e0c"
+                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
                     }
                 ]
             },
@@ -84,11 +84,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T07:44:35.140Z",
+                "created_at": "2023-01-30T15:32:52.748Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-29T07:44:35.140Z"
+                "updated_at": "2023-01-30T15:32:52.748Z"
             },
             "fulfillments": [
                 {
@@ -129,12 +129,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_L9umrgfCeoJ6Kx"
+                    "transaction_id": "order_LARIftVXGpRvPM"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-29T07:44:35.140Z"
+                    "timestamp": "2023-01-30T15:32:52.748Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -160,9 +160,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-29T07:44:35.140Z",
-            "updated_at": "2023-01-29T07:46:05.513Z",
-            "id": "5d560431-808d-46ad-b458-c7c6ce87591a"
+            "created_at": "2023-01-30T15:32:52.748Z",
+            "updated_at": "2023-01-30T15:33:40.004Z",
+            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
         }
     }
 }

--- a/logs/Nearshop/payload_for_cancel.json
+++ b/logs/Nearshop/payload_for_cancel.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "ebc85aa1-14b7-4614-a7d6-f62fd97f6bd0",
-        "message_id": "1b38ae2e-f717-4cfa-a186-2e350f05fb1a",
-        "timestamp": "2023-01-29T08:01:55.883Z",
+        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
+        "message_id": "81c85712-2351-4fdd-b0ab-95b3cdf18e89",
+        "timestamp": "2023-01-30T15:44:49.168Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -21,7 +21,7 @@
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [
                     {
-                        "id": "e7218f2a-bffb-5671-a35c-11bb6a08377d"
+                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
                     }
                 ]
             },
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-29T08:01:55.648Z",
+                "created_at": "2023-01-30T15:44:48.929Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-29T08:01:55.648Z"
+                "updated_at": "2023-01-30T15:44:48.929Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "135",
                     "currency": "INR",
-                    "transaction_id": "order_L9v5Ft4qCE2QUf"
+                    "transaction_id": "order_LARVKyWNagNm4m"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-29T08:01:55.648Z"
+                    "timestamp": "2023-01-30T15:44:48.929Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-29T08:01:55.648Z",
-            "updated_at": "2023-01-29T08:01:55.884Z",
-            "id": "1d0df8e6-8447-4728-a3bf-7fb91741b120"
+            "created_at": "2023-01-30T15:44:48.929Z",
+            "updated_at": "2023-01-30T15:44:49.168Z",
+            "id": "bb5bc364-5634-42c3-8032-5fe3644d9130"
         }
     }
 }

--- a/logs/Nearshop/search.json
+++ b/logs/Nearshop/search.json
@@ -7,9 +7,9 @@
 		"core_version": "1.1.0",
 		"bap_id": "ondc.indiastack.cloud",
 		"bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-		"transaction_id": "327aa9aa-f637-4a63-a143-13aae194e2ca",
-		"message_id": "beebd3ad-742a-4d41-aa19-f91cb4face96",
-		"timestamp": "2023-01-29T07:44:00.679Z",
+		"transaction_id": "45da55c3-fc56-4951-a613-b1c839717354",
+		"message_id": "5af81358-6231-4833-bcce-9a8adb1c0325",
+		"timestamp": "2023-01-30T15:32:10.166Z",
 		"ttl": "PT30S"
 	},
 	"message": {

--- a/logs/Nearshop/select.json
+++ b/logs/Nearshop/select.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "9516d137-2bf9-4c72-a378-02d4d2688192",
-        "timestamp": "2023-01-29T07:44:14.126Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "2dcdb2af-b174-404b-96a4-263d9f1d6971",
+        "timestamp": "2023-01-30T15:32:21.084Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/status.json
+++ b/logs/Nearshop/status.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
         "message_id": "d3ec328a-3e78-4518-88c2-c309c2237c43",
-        "timestamp": "2023-01-29T07:45:03.002Z",
+        "timestamp": "2023-01-30T15:32:58.103Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "5d560431-808d-46ad-b458-c7c6ce87591a"
+        "order_id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
     }
 }

--- a/logs/Nearshop/support.json
+++ b/logs/Nearshop/support.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "f17c74c0-e9e6-4529-8fec-3bfaf68968f1",
-        "timestamp": "2023-01-29T07:44:48.559Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "97ce2075-4837-46fd-913a-8ef4273e4ad9",
+        "timestamp": "2023-01-30T15:33:19.358Z",
         "ttl": "PT30S"
     },
     "message": {
-        "ref_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5"
+        "ref_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa"
     }
 }

--- a/logs/Nearshop/track.json
+++ b/logs/Nearshop/track.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "1a60ed36-b2df-448b-bd3d-f2b964490ca6",
-        "timestamp": "2023-01-29T07:44:43.140Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "f47345a7-fdd9-4aee-8851-408fc78c249c",
+        "timestamp": "2023-01-30T15:33:22.573Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "5d560431-808d-46ad-b458-c7c6ce87591a"
+        "order_id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
     }
 }

--- a/logs/Nearshop/update.json
+++ b/logs/Nearshop/update.json
@@ -9,15 +9,15 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "8ee6ec7b-b2f5-4a4e-a1ce-6f678ac48fe5",
-        "message_id": "de4ea0d9-89b8-4db6-a1df-3e4de1b8f6c5",
-        "timestamp": "2023-01-29T07:46:05.215Z",
+        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
+        "message_id": "8a1b82f9-8af0-4182-8715-9e777a5eef63",
+        "timestamp": "2023-01-30T15:33:39.746Z",
         "ttl": "PT30S"
     },
     "message": {
         "update_target": "item",
         "order": {
-            "id": "5d560431-808d-46ad-b458-c7c6ce87591a",
+            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207",
             "state": "Accepted",
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7"


### PR DESCRIPTION
**FIXED**

/on_select
'50' is not of type 'number' in $.quote.breakup[0].item.quantity.maximum.count
'50' is not of type 'number' in $.quote.breakup[0].item.quantity.available.count

/init
Wrong payload uploaded

/on_init
3 is not of type 'string' in $.payment.@ondc/org/buyer_app_finder_fee_amount

/on_confirm
provider.locations[].id mismatch

/cancel
Transaction Id mismatch

/on_cancel
Wrong payload uploaded

For on_cancel a separate order is created (payload_for_cancel file has its on_confirm payload.) as india stack buyer app invokes update api call again.

