### PR TITLE
Protean rsp logs - Fix for issue #431

### DIFF
--- a/logs/protean-rsp/COLLECTOR_RECON.json
+++ b/logs/protean-rsp/COLLECTOR_RECON.json
@@ -1,10 +1,10 @@
 {
   "context": {
-    "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
+    "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
     "country": "IND",
     "bpp_id": "rsp.proteantech.in",
     "city": "*",
-    "message_id": "9ea444dc-0643-49a9-a01b-41858b27776e",
+    "message_id": "b4ftdq00-e31b-411f-13ff-e56h57jss121",
     "core_version": "1.0.0",
     "ttl": "P2D",
     "bap_id": "cloud-adaptor.proteantech.in/kotak",
@@ -13,19 +13,20 @@
     "action": "collector_recon",
     "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
     "key": null,
-    "timestamp": "2023-01-12T12:30:01.469Z"
+    "timestamp": "2023-01-30T08:27:01.107Z"
   },
   "message": {
     "orderbook": {
       "orders": [
         {
+          "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
           "withholding_tax_gst": {
             "currency": "INR",
             "value": "0"
           },
           "receiver_app_uri": "https://ondcmp.nlincs.in/bpp",
-          "invoice_no": "INV222405902117800",
-          "created_at": "2023-01-12T12:30:01.469Z",
+          "invoice_no": "INV013306903127033",
+          "created_at": "2023-01-30T08:27:01.107Z",
           "deduction_by_collector": {
             "currency": "INR",
             "value": "0"
@@ -33,7 +34,7 @@
           "receiver_app_id": "ondcmp.nlincs.in",
           "settlement_reason_code": "01",
           "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-          "updated_at": "2023-01-12T12:30:01.469Z",
+          "updated_at": "2023-01-30T08:27:01.107Z",
           "provider": {
             "address": "NewDelhi",
             "name": {
@@ -44,7 +45,6 @@
           "payerdetails": {
             "payer_bank_code": "KKBK0000958",
             "payer_name": "ONDC Buyer Pool Account",
-            "payer_virtual_payment_address": "",
             "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
             "payer_account_no": 6410125397001
           },
@@ -53,29 +53,26 @@
             "@ondc/org/buyer_app_finder_fee_type": "Percent",
             "collected_by": "BAP",
             "params": {
-              "transaction_id": "24001267",
-              "amount": "1270.00",
+              "transaction_id": "10021a",
+              "amount": "1270",
               "transaction_status": "PAID",
               "currency": "INR"
             },
-            "type": "ON_ORDER",
+            "type": "ON-ORDER",
             "@ondc/org/settlement_basis_status": "Assert",
-            "uri": null,
             "@ondc/org/settlement_details": [
               {
                 "beneficiary_address": "Dhampur Green",
-                "settlement_status": "READY",
-                "settlement_ifsc_code": "ICIC0000212",
-                "branch_name": "CHENNAI - SANTHOME",
-                "settlement_counterparty": "buyer-app",
+                "settlement_status": "NOT-PAID",
+                "branch_name": "New Delhi Main Branch",
+                "settlement_counterparty": "seller-app",
                 "settlement_phase": "sale-amount",
-                "bank_name": "ICICI BANK LTD",
+                "bank_name": "State Bank of India",
                 "settlement_amount": 1270,
-                "settlement_reference": "3122637",
-                "settlement_timestamp": "2023-01-12T12:30:01.469Z",
-                "settlement_bank_account_no": "021205008922",
-                "upi_address": null,
-                "settlement_type": "NEFT"
+                "settlement_ifsc_code": "SBIN0000691",
+                "settlement_timestamp": "2023-01-30T08:27:01.107Z",
+                "settlement_bank_account_no": "32828742093",
+                "settlement_type": "neft"
               }
             ],
             "@ondc/org/return_window": "0",
@@ -84,12 +81,11 @@
             "@ondc/org/withholding_amount_status": "Assert",
             "@ondc/org/return_window_status": "Assert",
             "@ondc/org/withholding_amount": "0.0",
-            "time": null,
             "@ondc/org/collected_by_status": "Assert",
             "status": "PAID",
             "@ondc/org/buyer_app_finder_fee_amount": "0"
           },
-          "id": "ghc11af11",
+          "id": "k001abcc31",
           "state": "Completed",
           "withholding_tax_tds": {
             "currency": "INR",

--- a/logs/protean-rsp/ONCOLLECTOR_RECON.json
+++ b/logs/protean-rsp/ONCOLLECTOR_RECON.json
@@ -1,10 +1,10 @@
 {
   "context": {
-    "transaction_id": "fc9c7f85-dbc3-40af-9913-628c7be9ecee",
+    "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
     "country": "IND",
     "bpp_id": "rsp.proteantech.in",
     "city": "*",
-    "message_id": "2731405b-2072-4c09-8d3c-6667e9341a1a",
+    "message_id": "b4ftdq00-e31b-411f-13ff-e56h57jss121",
     "core_version": "1.0.0",
     "ttl": "P2D",
     "bap_id": "cloud-adaptor.proteantech.in/kotak",
@@ -13,25 +13,21 @@
     "action": "on_collector_recon",
     "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
     "key": null,
-    "timestamp": "2023-01-12T12:38:02.001Z"
+    "timestamp": "2023-01-30T08:37:46.031Z"
   },
   "message": {
     "orderbook": {
       "order": [
         {
-          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
-          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
           "counterparty_diff_amount": {
             "currency": "INR",
             "value": "20"
           },
           "counterparty_recon_status": "03",
-          "invoice_no": "INV222405902117800",
-          "created_at": "2023-01-12T12:38:02.001Z",
-           "diff_amount": {	
-            "currency": "INR",	
-            "value": "0"	
-          },
+          "invoice_no": "INV013306903127033",
+          "created_at": "2023-01-30T08:37:46.031Z",
           "recon_status": "01",
           "message": {
             "code": "less",
@@ -40,9 +36,9 @@
           "order_recon_status": "01",
           "receiver_app_id": "ondcmp.nlincs.in",
           "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-          "updated_at": "2023-01-12T12:38:02.001Z",
-          "id": "ghc11af11",
-          "settlement_reference_no": "KC356687GK"
+          "updated_at": "2023-01-30T08:37:46.031Z",
+          "id": "k001abcc31",
+          "settlement_reference_no": "BA012A338Z"
         }
       ]
     }

--- a/logs/protean-rsp/ONRECEIVER_RECON.json
+++ b/logs/protean-rsp/ONRECEIVER_RECON.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://rsp.proteantech.in",
     "bpp_id": "ondcmp.nlincs.in",
     "bpp_uri": "https://ondcmp.nlincs.in/bpp",
-    "transaction_id": "7asa911a-6cbe-4ad3-94e9-acb96aaff432",
-    "message_id": "22aa811a-61be-55d3-99e9-cbf12abff347",
-    "timestamp": "2023-01-12T12:37:11.121Z",
+    "transaction_id": "9c23926b-c423-484a-a3ac-d4ddd8f21ffd",
+    "message_id": "550ad5ed-edbb-49e3-9687-286212f42400",
+    "timestamp": "2023-01-30T08:37:02.191Z",
     "key": null,
     "ttl": "P2D"
   },
@@ -19,14 +19,14 @@
     "orderbook": {
       "orders": [
         {
-          "id": "ghc11af11",
-          "invoice_no": "INV222405902117800",
+          "id": "k113eqa32",
+          "invoice_no": "INV013306903127033",
           "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
           "receiver_app_id": "ondcmp.nlincs.in",
           "order_recon_status": "01",
-          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
-          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
-          "settlement_reference_no": "KC356687GK",
+          "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
+          "settlement_reference_no": "BA012A338Z",
           "recon_status": "01",
           "counterparty_recon_status": "03",
           "counterparty_diff_amount": {
@@ -37,12 +37,8 @@
             "name": "lesser amount",
             "code": "less"
           },
-          "created_at": "2023-01-12T12:37:11.121Z",
-          "updated_at": "2023-01-12T12:37:11.121Z",
-          "diff_amount": {
-            "currency": "INR",
-            "value": "0"
-          }
+          "created_at": "2023-01-30T08:37:02.191Z",
+          "updated_at": "2023-01-30T08:37:02.191Z"
         }
       ]
     }

--- a/logs/protean-rsp/ON_RECON_STATUS.json
+++ b/logs/protean-rsp/ON_RECON_STATUS.json
@@ -1,0 +1,46 @@
+{
+  "context": {
+    "transaction_id": "3qaa811a-5cbe-4bd1-94e9-cvf96aaff321",
+    "country": "IND",
+    "bpp_id": "rsp.proteantech.in",
+    "city": "*",
+    "message_id": "45aa811a-5cbe-uai3-94e8-ibfi6aagf300",
+    "core_version": "1.0.0",
+    "ttl": "P2D",
+    "bap_id": "cloud-adaptor.proteantech.in/kotak",
+    "domain": "nic2004:12345",
+    "bpp_uri": "https://rsp.proteantech.in",
+    "action": "on_recon_status",
+    "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
+    "key": null,
+    "timestamp": "2023-01-30T08:39:11.003Z"
+  },
+  "message": {
+    "orderbook": {
+      "order": [
+        {
+          "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
+          "counterparty_diff_amount": {
+            "currency": "INR",
+            "value": "20"
+          },
+          "counterparty_recon_status": "03",
+          "invoice_no": "INV013306903127033",
+          "created_at": "2023-01-30T08:39:11.003Z",
+          "recon_status": "01",
+          "message": {
+            "code": "less",
+            "name": "lesser amount"
+          },
+          "order_recon_status": "01",
+          "receiver_app_id": "ondcmp.nlincs.in",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "updated_at": "2023-01-30T08:39:11.003Z",
+          "id": "k001abcc31",
+          "settlement_reference_no": "BA012A338Z"
+        }
+      ]
+    }
+  }
+}

--- a/logs/protean-rsp/ON_SETTLE.json
+++ b/logs/protean-rsp/ON_SETTLE.json
@@ -6,12 +6,12 @@
     "action": "on_settle",
     "core_version": "1.0.0",
     "bap_id": "rsp.proteantech.in",
-    "bap_uri": "https://rsp.proteantech.in",
+    "bap_uri": "rsp.proteantech.in",
     "bpp_id": "formatter.proteantech.in",
     "bpp_uri": "http://formatter.proteantech.in",
-    "transaction_id": "b2d206ad-b1a0-4de3-85cb-f4988832ae52",
-    "message_id": "7274e08b-7188-446e-bd23-2b3c800853ff",
-    "timestamp": "2023-01-12T12:36:00.008Z",
+    "transaction_id": "93095aa8-6420-4175-b3f1-04133673eaed",
+    "message_id": "a69ec5bd-2395-4d31-8bfe-5bfe632d6346",
+    "timestamp": "2023-01-30T08:33:11.020Z",
     "key": null,
     "ttl": "P2D"
   },
@@ -24,11 +24,9 @@
             "currency": "INR",
             "value": "1270.0"
           },
-          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
           "state": "01",
-          "settlement_reference_no": "KC356687GK",
-          "error_code": "",
-          "error_message": ""
+          "settlement_reference_no": "BA012A338Z"
         }
       ]
     }

--- a/logs/protean-rsp/RECEIVER_RECON.json
+++ b/logs/protean-rsp/RECEIVER_RECON.json
@@ -9,9 +9,9 @@
     "bap_uri": "https://rsp.proteantech.in",
     "bpp_id": "ondcmp.nlincs.in",
     "bpp_uri": "https://ondcmp.nlincs.in/bpp",
-    "transaction_id": "9c5e1976-e300-442a-943c-e417fc0d2e54",
-    "message_id": "ac214f77-55e3-4b68-8444-ecc475699a46",
-    "timestamp": "2023-01-12T12:36:10.022Z",
+    "transaction_id": "9c23926b-c423-484a-a3ac-d4ddd8f21ffd",
+    "message_id": "550ad5ed-edbb-49e3-9687-286212f42400",
+    "timestamp": "2023-01-30T08:34:05.102Z",
     "key": null,
     "ttl": "P2D"
   },
@@ -19,11 +19,10 @@
     "orderbook": {
       "orders": [
         {
-          "id": "ghc11af11",
-          "invoice_no": "INV222405902117800",
+          "id": "k001abcc31",
+          "invoice_no": "INV013306903127033",
           "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
           "receiver_app_id": "ondcmp.nlincs.in",
-          "order_recon_status": null,
           "state": "Completed",
           "provider": {
             "name": {
@@ -33,14 +32,13 @@
             "address": "NewDelhi"
           },
           "payment": {
-            "uri": null,
             "params": {
-              "transaction_id": "24001267",
+              "transaction_id": "10021a",
               "currency": "INR",
-              "amount": "1270.00",
+              "amount": "1270",
               "transaction_status": "PAID"
             },
-            "type": "ON_ORDER",
+            "type": "ON-ORDER",
             "status": "PAID",
             "collected_by": "BAP",
             "@ondc/org/collected_by_status": "Assert",
@@ -56,19 +54,18 @@
             "@ondc/org/settlement_window_status": "Assert",
             "@ondc/org/settlement_details": [
               {
-                "settlement_counterparty": "buyer-app",
+                "settlement_counterparty": "seller-app",
                 "settlement_phase": "sale-amount",
                 "settlement_amount": 1270,
-                "settlement_type": "NEFT",
-                "settlement_bank_account_no": "021205008922",
-                "settlement_ifsc_code": "ICIC0000212",
-                "upi_address": null,
-                "bank_name": "ICICI BANK LTD",
-                "branch_name": "CHENNAI - SANTHOME",
+                "settlement_type": "neft",
+                "settlement_bank_account_no": "32828742093",
+                "settlement_ifsc_code": "SBIN0000691",
+                "bank_name": "State Bank of India",
+                "branch_name": "New Delhi Main Branch",
                 "beneficiary_address": "Dhampur Green",
                 "settlement_status": "PAID",
-                "settlement_reference": "KC356687GK",
-                "settlement_timestamp": "2023-01-12T12:36:10.022Z"
+                "settlement_reference": "BA012A338Z",
+                "settlement_timestamp": "2023-01-30T08:34:05.102Z"
               }
             ]
           },
@@ -84,29 +81,19 @@
             "currency": "INR",
             "value": "0"
           },
-          "payerDetails": {
-            "payer_name": "ONDC Buyer Pool Account",
-            "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
+          "payerdetails": {
+            "payer_name": "ondc buyer pool account",
+            "payer_address": "27 bkc, c 27, g block, bandra kurla complex. bandra (e), mumbai 400051, maharashtra, india",
             "payer_account_no": 2034191369,
-            "payer_bank_code": "KKBK0000958",
-            "payer_virtual_payment_address": ""
+            "payer_bank_code": "kkbk0000958"
           },
           "settlement_reason_code": "01",
-          "correction": null,
-          "transaction_id": "111424dc-0613-5219-a11b-67858b2877ff",
-          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
-          "settlement_reference_no": "KC356687GK",
+          "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
+          "settlement_reference_no": "BA012A338Z",
           "recon_status": "01",
-          "message": {
-            "name": null,
-            "code": null
-          },
-          "created_at": "2023-01-12T12:36:10.022Z",
-          "updated_at": "2023-01-12T12:36:10.022Z",
-          "diff_amount": {
-            "currency": null,
-            "value": null
-          }
+          "created_at": "2023-01-30T08:34:05.102Z",
+          "updated_at": "2023-01-30T08:34:05.102Z"
         }
       ]
     }

--- a/logs/protean-rsp/RECON_STATUS.json
+++ b/logs/protean-rsp/RECON_STATUS.json
@@ -1,0 +1,23 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "recon_status",
+    "core_version": "1.0.0",
+    "bap_id": "cloud-adaptor.proteantech.in/kotak",
+    "bap_uri": "https://stgpayment.kotak-kaymall.com/api",
+    "bpp_id": "rsp.proteantech.in",
+    "bpp_uri": "https://rsp.proteantech.in",
+    "transaction_id": "3qaa811a-5cbe-4bd1-94e9-cvf96aaff321",
+    "message_id": "45aa811a-5cbe-uai3-94e8-ibfi6aagf300",
+    "timestamp": "2023-01-30T08:38:04.011Z",
+    "key": null,
+    "ttl": "P2D"
+  },
+  "message": {
+    "reconstatus": {
+      "transaction_id": "a1cbrcy6-ui12-fi42-89qr-u890kl600565"
+    }
+  }
+}

--- a/logs/protean-rsp/SETTLE.json
+++ b/logs/protean-rsp/SETTLE.json
@@ -1,55 +1,50 @@
 {
   "context": {
-    "transaction_id": "b22642a2-6556-4c12-bc00-d5e4dafba729",
+    "transaction_id": "93095aa8-6420-4175-b3f1-04133673eaed",
     "country": "IND",
     "bpp_id": "formatter.proteantech.in",
     "city": "*",
-    "message_id": "0e45a377-ca37-4a2b-840a-233fc26d2263",
+    "message_id": "a69ec5bd-2395-4d31-8bfe-5bfe632d6346",
     "core_version": "1.0.0",
     "ttl": "P2D",
     "bap_id": "rsp.proteantech.in",
     "domain": "nic2004:12345",
-    "bpp_uri": "http://formatter.proteantech.in",
+    "bpp_uri": "http://localhost:8081/",
     "action": "settle",
-    "bap_uri": "https://rsp.proteantech.in",
+    "bap_uri": "http://formatter.proteantech.in",
     "key": null,
-    "timestamp": "2023-01-12T12:35:11.558Z"
+    "timestamp": "2023-01-30T08:31:12.021Z"
   },
   "message": {
     "settlement": {
       "settlements": [
         {
-          "payee_account_type": "02",
-          "settlement_id": "022d9c75-a072-4a08-a0c3-5e2fcceac1b4",
-          "curr_type": "INR",
-          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
-          "bank_name": "ICICI BANK LTD",
-          "purpose_code": "01",
-          "state": "02",
-          "payer_address": "27 BKC, C 27, G Block, Bandra Kurla Complex. Bandra (E), Mumbai 400051, Maharashtra, India",
-          "timestamp": "2023-01-12T12:35:11.558Z",
-          "payee_bank_code": "ICIC0000212",
-          "error_message": null,
+          "payee_bank_code": "SBIN0000691",
           "amount": {
             "currency": "INR",
             "value": "1270.0"
           },
+          "payee_account_type": "02",
+          "settlement_id": "ff842b30-3fa5-41fb-972e-0c5397f49add",
           "payee_address": "Dhampur Green",
-          "payee_account_no": "021205008922",
-          "payer_virtual_payment_address": "",
-          "payee_virtual_payment_address": null,
+          "payee_account_no": "32828742093",
+          "curr_type": "INR",
           "prev_settlement_reference_no": [],
           "payer_account_no": 6410125397001,
           "receiver_app_id": "ondcmp.nlincs.in",
-          "payer_bank_code": "KKBK0000958",
-          "payment_type": "01",
-          "payee_name": "NSTORE TECHNOLOGIES PRIVATE LIMITED",
-          "error_code": null,
-          "settlement_reference_no": null,
-          "payer_name": "ONDC Buyer Pool Account",
+          "payer_bank_code": "kkbk0000958",
+          "collector_app_id": "cloud-adaptor.proteantech.in/kotak",
+          "payment_type": "02",
+          "payee_name": "New Delhi Main Branch",
+          "bank_name": "State Bank of India",
+          "purpose_code": "01",
+          "state": "02",
+          "payer_name": "ondc buyer pool account",
           "remarks": {
-            "name": null
-          }
+            "name": "name"
+          },
+          "payer_address": "27 bkc, c 27, g block, bandra kurla complex. bandra (e), mumbai 400051, maharashtra, india",
+          "timestamp": "2023-01-30T08:31:12.021Z"
         }
       ]
     }


### PR DESCRIPTION
> 1. Transaction_id & Message_id mismatch in every API (or pair of APIs), this was raised earlier too - **Fixed**
> 2. /collector_recon
> 
> * payment type should be ON-ORDER instead of ON_ORDER - **Fixed**
> * settlement type enum should be in lower case (suggestive) - **Fixed**
> * settlement status is ready in On-Order payment, we need to understand this status - **Fixed**
> 
> 3. /on_settle
> 
> * error code should not be sent if there is no value - **Fixed**
> 
> 4. /receiver_recon
> 
> * payer details should not be in camelcase - **Fixed**
> * correction object should not be sent in /receiver_recon, it is to be added in case of an error in reconciliation - **Fixed**
> * orders.transaction id and collector_recon context.transaction id are same - **As expected as discussed**
> * diff_amount and message should not be sent, it is to be initiated by Receiver in case of an error in reconciliation - **Fixed**
> 
> 5. /on_collector_recon
> 
> * order transaction id and collector_recon context transaction id are same  - **As expected as discussed**

