### PR TITLE
Nearshop Verification Logs (Review, Comments, & Fixes)

### DIFF
--- a/logs/Nearshop/cancel.json
+++ b/logs/Nearshop/cancel.json
@@ -9,13 +9,13 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
-        "message_id": "b5dd4ef5-0d2d-44d1-903e-c30728f99f96",
-        "timestamp": "2023-01-30T15:45:08.910Z",
+        "transaction_id": "11d076d2-8a5d-4ae3-bb26-c8e61efeb384",
+        "message_id": "796029fc-8617-42d2-a385-ceba4346e806",
+        "timestamp": "2023-01-31T08:21:39.005Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "bb5bc364-5634-42c3-8032-5fe3644d9130",
+        "order_id": "ad303296-e444-4b16-ab1b-5f73bac1c577",
         "cancellation_reason_id": "001"
     }
 }

--- a/logs/Nearshop/confirm.json
+++ b/logs/Nearshop/confirm.json
@@ -9,14 +9,14 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "80cd8cf1-4633-4ae3-b3c1-83747bf38c5c",
-        "timestamp": "2023-01-30T15:32:52.784Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "fbdaf8fc-5785-4d54-9b73-6c5374445efd",
+        "timestamp": "2023-01-31T08:51:42.331Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
-            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207",
+            "id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da",
             "state": "Created",
             "billing": {
                 "address": {
@@ -28,11 +28,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:32:52.748Z",
+                "created_at": "2023-01-31T08:51:42.293Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-30T15:32:52.748Z"
+                "updated_at": "2023-01-31T08:51:42.293Z"
             },
             "fulfillments": [
                 {
@@ -107,12 +107,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_LARIftVXGpRvPM"
+                    "transaction_id": "order_LAj02zUyyryAwD"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-30T15:32:52.748Z"
+                    "timestamp": "2023-01-31T08:51:42.293Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -130,8 +130,8 @@
                     }
                 ]
             },
-            "created_at": "2023-01-30T15:32:52.748Z",
-            "updated_at": "2023-01-30T15:32:52.748Z",
+            "created_at": "2023-01-31T08:51:42.293Z",
+            "updated_at": "2023-01-31T08:51:42.293Z",
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
                 "locations": [

--- a/logs/Nearshop/init.json
+++ b/logs/Nearshop/init.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "7cf90b6b-52a4-4028-9869-598170816df5",
-        "timestamp": "2023-01-30T15:32:41.511Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "d0e32b3a-e8dd-4cd8-8eb3-7dd2ba5a5977",
+        "timestamp": "2023-01-31T08:51:32.852Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -26,12 +26,12 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:32:41.454Z",
+                "created_at": "2023-01-31T08:51:32.822Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
                 "tax_number": "",
-                "updated_at": "2023-01-30T15:32:41.454Z"
+                "updated_at": "2023-01-31T08:51:32.822Z"
             },
             "fulfillments": [
                 {

--- a/logs/Nearshop/on_cancel.json
+++ b/logs/Nearshop/on_cancel.json
@@ -9,31 +9,14 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
-        "message_id": "b5dd4ef5-0d2d-44d1-903e-c30728f99f96",
-        "timestamp": "2023-01-30T15:45:09.140Z",
+        "transaction_id": "11d076d2-8a5d-4ae3-bb26-c8e61efeb384",
+        "message_id": "796029fc-8617-42d2-a385-ceba4346e806",
+        "timestamp": "2023-01-31T08:21:39.130Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
             "state": "Cancelled",
-            "provider": {
-                "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                "locations": [
-                    {
-                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
-                    }
-                ]
-            },
-            "items": [
-                {
-                    "id": "fea40eec-fa72-4230-9e5d-40eb606e70db",
-                    "fulfillment_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "quantity": {
-                        "count": 1
-                    }
-                }
-            ],
             "quote": {
                 "price": {
                     "currency": "INR",
@@ -64,95 +47,9 @@
                 ],
                 "ttl": "P4D"
             },
-            "billing": {
-                "address": {
-                    "area_code": "560064",
-                    "city": "Bangalore",
-                    "country": "IN",
-                    "door": "ABC Street, ABC",
-                    "locality": "ABC Street, ABC",
-                    "name": "ABC Street, ABC",
-                    "state": "KARNATAKA"
-                },
-                "created_at": "2023-01-30T15:44:48.929Z",
-                "email": "sumitait5219@gmail.com",
-                "name": "SumitKumar",
-                "phone": "9886394142",
-                "updated_at": "2023-01-30T15:44:48.929Z"
-            },
-            "fulfillments": [
-                {
-                    "end": {
-                        "contact": {
-                            "email": "sumitait5219@gmail.com",
-                            "phone": "9886394142"
-                        },
-                        "location": {
-                            "address": {
-                                "area_code": "560064",
-                                "city": "Bangalore",
-                                "country": "IN",
-                                "door": "",
-                                "locality": "",
-                                "name": "ABC Street, ABC",
-                                "state": "KARNATAKA"
-                            },
-                            "gps": "12.9159993,77.6195245"
-                        },
-                        "person": {
-                            "name": "Sumit Kumar"
-                        }
-                    },
-                    "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "tracking": false,
-                    "type": "Delivery",
-                    "provider_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "state": {
-                        "descriptor": {
-                            "name": "Pending"
-                        }
-                    }
-                }
-            ],
-            "payment": {
-                "type": "ON-ORDER",
-                "params": {
-                    "amount": "135",
-                    "currency": "INR",
-                    "transaction_id": "order_LARVKyWNagNm4m"
-                },
-                "status": "PAID",
-                "collected_by": "BAP",
-                "time": {
-                    "timestamp": "2023-01-30T15:44:48.929Z"
-                },
-                "@ondc/org/buyer_app_finder_fee_type": "percent",
-                "@ondc/org/buyer_app_finder_fee_amount": "3",
-                "@ondc/org/settlement_details": [
-                    {
-                        "settlement_ifsc_code": "UTIB0000234",
-                        "beneficiary_name": "Nearshop Pvt Ltd",
-                        "settlement_bank_account_no": "810030027666312",
-                        "bank_name": "Axis Bank",
-                        "settlement_type": "neft",
-                        "branch_name": "Jakkur",
-                        "settlement_counterparty": "seller-app",
-                        "settlement_phase": "sale-amount",
-                        "settlement_status": "NOT-PAID"
-                    }
-                ]
-            },
-            "addOns": [],
-            "offers": [],
-            "documents": [
-                {
-                    "url": "",
-                    "label": ""
-                }
-            ],
-            "created_at": "2023-01-30T15:44:48.929Z",
-            "updated_at": "2023-01-30T15:44:49.168Z",
-            "id": "bb5bc364-5634-42c3-8032-5fe3644d9130",
+            "created_at": "2023-01-31T08:21:14.395Z",
+            "updated_at": "2023-01-31T08:21:14.639Z",
+            "id": "ad303296-e444-4b16-ab1b-5f73bac1c577",
             "cancellation": {
                 "cancelled_by": "ondc.indiastack.cloud",
                 "reason": {

--- a/logs/Nearshop/on_confirm.json
+++ b/logs/Nearshop/on_confirm.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "80cd8cf1-4633-4ae3-b3c1-83747bf38c5c",
-        "timestamp": "2023-01-30T15:32:53.003Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "fbdaf8fc-5785-4d54-9b73-6c5374445efd",
+        "timestamp": "2023-01-31T08:51:42.521Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:32:52.748Z",
+                "created_at": "2023-01-31T08:51:42.293Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-30T15:32:52.748Z"
+                "updated_at": "2023-01-31T08:51:42.293Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_LARIftVXGpRvPM"
+                    "transaction_id": "order_LAj02zUyyryAwD"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-30T15:32:52.748Z"
+                    "timestamp": "2023-01-31T08:51:42.293Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-30T15:32:52.748Z",
-            "updated_at": "2023-01-30T15:32:53.003Z",
-            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
+            "created_at": "2023-01-31T08:51:42.293Z",
+            "updated_at": "2023-01-31T08:51:42.522Z",
+            "id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da"
         }
     }
 }

--- a/logs/Nearshop/on_init.json
+++ b/logs/Nearshop/on_init.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "7cf90b6b-52a4-4028-9869-598170816df5",
-        "timestamp": "2023-01-30T15:32:41.731Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "d0e32b3a-e8dd-4cd8-8eb3-7dd2ba5a5977",
+        "timestamp": "2023-01-31T08:51:33.045Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -68,12 +68,12 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:32:41.454Z",
+                "created_at": "2023-01-31T08:51:32.822Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
                 "tax_number": "",
-                "updated_at": "2023-01-30T15:32:41.454Z"
+                "updated_at": "2023-01-31T08:51:32.822Z"
             },
             "fulfillments": [
                 {

--- a/logs/Nearshop/on_search.json
+++ b/logs/Nearshop/on_search.json
@@ -7,9 +7,9 @@
 		"core_version": "1.1.0",
 		"bap_id": "ondc.indiastack.cloud",
 		"bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-		"transaction_id": "45da55c3-fc56-4951-a613-b1c839717354",
-		"message_id": "5af81358-6231-4833-bcce-9a8adb1c0325",
-		"timestamp": "2023-01-30T15:32:10.782Z",
+		"transaction_id": "48e6eb1e-b911-4530-8245-90f19c010246",
+		"message_id": "b053ce28-93a9-4028-8409-673c9d3a16b6",
+		"timestamp": "2023-01-31T08:17:24.694Z",
 		"ttl": "PT30S",
 		"bpp_id": "api.staging.nearshop.in",
 		"bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1"

--- a/logs/Nearshop/on_select.json
+++ b/logs/Nearshop/on_select.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "2dcdb2af-b174-404b-96a4-263d9f1d6971",
-        "timestamp": "2023-01-30T15:32:24.272Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "4222cd0c-53d9-4623-8832-f0a9a0526654",
+        "timestamp": "2023-01-31T08:51:26.192Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/on_status.json
+++ b/logs/Nearshop/on_status.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "d3ec328a-3e78-4518-88c2-c309c2237c43",
-        "timestamp": "2023-01-30T15:32:58.417Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "e3ec328a-3e78-4518-88c2-c309c2237c88",
+        "timestamp": "2023-01-31T08:51:55.811Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:32:52.748Z",
+                "created_at": "2023-01-31T08:51:42.293Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-30T15:32:52.748Z"
+                "updated_at": "2023-01-31T08:51:42.293Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "240",
                     "currency": "INR",
-                    "transaction_id": "order_LARIftVXGpRvPM"
+                    "transaction_id": "order_LAj02zUyyryAwD"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-30T15:32:52.748Z"
+                    "timestamp": "2023-01-31T08:51:42.293Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-30T15:32:52.748Z",
-            "updated_at": "2023-01-30T15:32:53.003Z",
-            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
+            "created_at": "2023-01-31T08:51:42.293Z",
+            "updated_at": "2023-01-31T08:51:42.522Z",
+            "id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da"
         }
     }
 }

--- a/logs/Nearshop/on_support.json
+++ b/logs/Nearshop/on_support.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "97ce2075-4837-46fd-913a-8ef4273e4ad9",
-        "timestamp": "2023-01-30T15:33:19.583Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "a3c5878f-75f2-4884-9c7e-abcf53fa766b",
+        "timestamp": "2023-01-31T08:51:55.837Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/on_track.json
+++ b/logs/Nearshop/on_track.json
@@ -9,15 +9,15 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "f47345a7-fdd9-4aee-8851-408fc78c249c",
-        "timestamp": "2023-01-30T15:33:22.797Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "e25dbe91-a197-4dd5-9ca4-63459aff0518",
+        "timestamp": "2023-01-31T08:51:48.497Z",
         "ttl": "PT30S"
     },
     "message": {
         "tracking": {
             "tl_method": "http/get",
-            "url": "https://nearshop.in?order_id=586c7254-02f4-47d0-ab1c-6ec37df13207",
+            "url": "https://nearshop.in?order_id=6dd9d2c0-9830-48fc-80fa-7f32740c76da",
             "status": "active"
         }
     }

--- a/logs/Nearshop/on_update.json
+++ b/logs/Nearshop/on_update.json
@@ -9,22 +9,14 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "8a1b82f9-8af0-4182-8715-9e777a5eef63",
-        "timestamp": "2023-01-30T15:33:39.970Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "8baf2980-68ef-425c-82a5-dae6fb144a05",
+        "timestamp": "2023-01-31T08:52:16.559Z",
         "ttl": "PT30S"
     },
     "message": {
         "order": {
             "state": "Accepted",
-            "provider": {
-                "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                "locations": [
-                    {
-                        "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7_location"
-                    }
-                ]
-            },
             "items": [
                 {
                     "id": "fea40eec-fa72-4230-9e5d-40eb606e70db",
@@ -57,9 +49,11 @@
                         },
                         "@ondc/org/title_type": "item",
                         "title": "Watermelon",
-                        "price": {
-                            "currency": "INR",
-                            "value": "105"
+                        "item": {
+                            "price": {
+                                "currency": "INR",
+                                "value": "105"
+                            }
                         }
                     },
                     {
@@ -74,95 +68,9 @@
                 ],
                 "ttl": "P4D"
             },
-            "billing": {
-                "address": {
-                    "area_code": "560064",
-                    "city": "Bangalore",
-                    "country": "IN",
-                    "door": "ABC Street, ABC",
-                    "locality": "ABC Street, ABC",
-                    "name": "ABC Street, ABC",
-                    "state": "KARNATAKA"
-                },
-                "created_at": "2023-01-30T15:32:52.748Z",
-                "email": "sumitait5219@gmail.com",
-                "name": "SumitKumar",
-                "phone": "9886394142",
-                "updated_at": "2023-01-30T15:32:52.748Z"
-            },
-            "fulfillments": [
-                {
-                    "end": {
-                        "contact": {
-                            "email": "sumitait5219@gmail.com",
-                            "phone": "9886394142"
-                        },
-                        "location": {
-                            "address": {
-                                "area_code": "560064",
-                                "city": "Bangalore",
-                                "country": "IN",
-                                "door": "",
-                                "locality": "",
-                                "name": "ABC Street, ABC",
-                                "state": "KARNATAKA"
-                            },
-                            "gps": "12.9159993,77.6195245"
-                        },
-                        "person": {
-                            "name": "Sumit Kumar"
-                        }
-                    },
-                    "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "tracking": false,
-                    "type": "Delivery",
-                    "provider_id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7",
-                    "state": {
-                        "descriptor": {
-                            "name": "Pending"
-                        }
-                    }
-                }
-            ],
-            "payment": {
-                "type": "ON-ORDER",
-                "params": {
-                    "amount": "240",
-                    "currency": "INR",
-                    "transaction_id": "order_LARIftVXGpRvPM"
-                },
-                "status": "PAID",
-                "collected_by": "BAP",
-                "time": {
-                    "timestamp": "2023-01-30T15:32:52.748Z"
-                },
-                "@ondc/org/buyer_app_finder_fee_type": "percent",
-                "@ondc/org/buyer_app_finder_fee_amount": "3",
-                "@ondc/org/settlement_details": [
-                    {
-                        "settlement_ifsc_code": "UTIB0000234",
-                        "beneficiary_name": "Nearshop Pvt Ltd",
-                        "settlement_bank_account_no": "810030027666312",
-                        "bank_name": "Axis Bank",
-                        "settlement_type": "neft",
-                        "branch_name": "Jakkur",
-                        "settlement_counterparty": "seller-app",
-                        "settlement_phase": "sale-amount",
-                        "settlement_status": "NOT-PAID"
-                    }
-                ]
-            },
-            "addOns": [],
-            "offers": [],
-            "documents": [
-                {
-                    "url": "",
-                    "label": ""
-                }
-            ],
-            "created_at": "2023-01-30T15:32:52.748Z",
-            "updated_at": "2023-01-30T15:33:40.004Z",
-            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
+            "created_at": "2023-01-31T08:51:42.293Z",
+            "updated_at": "2023-01-31T08:51:42.522Z",
+            "id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da"
         }
     }
 }

--- a/logs/Nearshop/payload_for_cancel.json
+++ b/logs/Nearshop/payload_for_cancel.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "1c74a024-a736-453a-90d0-c5a8b927525f",
-        "message_id": "81c85712-2351-4fdd-b0ab-95b3cdf18e89",
-        "timestamp": "2023-01-30T15:44:49.168Z",
+        "transaction_id": "11d076d2-8a5d-4ae3-bb26-c8e61efeb384",
+        "message_id": "1699cdfc-960d-4e91-823a-9e42317db11a",
+        "timestamp": "2023-01-31T08:21:14.638Z",
         "ttl": "PT30S"
     },
     "message": {
@@ -74,11 +74,11 @@
                     "name": "ABC Street, ABC",
                     "state": "KARNATAKA"
                 },
-                "created_at": "2023-01-30T15:44:48.929Z",
+                "created_at": "2023-01-31T08:21:14.395Z",
                 "email": "sumitait5219@gmail.com",
                 "name": "SumitKumar",
                 "phone": "9886394142",
-                "updated_at": "2023-01-30T15:44:48.929Z"
+                "updated_at": "2023-01-31T08:21:14.395Z"
             },
             "fulfillments": [
                 {
@@ -119,12 +119,12 @@
                 "params": {
                     "amount": "135",
                     "currency": "INR",
-                    "transaction_id": "order_LARVKyWNagNm4m"
+                    "transaction_id": "order_LAiTtfSfrcVVtD"
                 },
                 "status": "PAID",
                 "collected_by": "BAP",
                 "time": {
-                    "timestamp": "2023-01-30T15:44:48.929Z"
+                    "timestamp": "2023-01-31T08:21:14.395Z"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "3",
@@ -150,9 +150,9 @@
                     "label": ""
                 }
             ],
-            "created_at": "2023-01-30T15:44:48.929Z",
-            "updated_at": "2023-01-30T15:44:49.168Z",
-            "id": "bb5bc364-5634-42c3-8032-5fe3644d9130"
+            "created_at": "2023-01-31T08:21:14.395Z",
+            "updated_at": "2023-01-31T08:21:14.639Z",
+            "id": "ad303296-e444-4b16-ab1b-5f73bac1c577"
         }
     }
 }

--- a/logs/Nearshop/search.json
+++ b/logs/Nearshop/search.json
@@ -7,16 +7,16 @@
 		"core_version": "1.1.0",
 		"bap_id": "ondc.indiastack.cloud",
 		"bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-		"transaction_id": "45da55c3-fc56-4951-a613-b1c839717354",
-		"message_id": "5af81358-6231-4833-bcce-9a8adb1c0325",
-		"timestamp": "2023-01-30T15:32:10.166Z",
+		"transaction_id": "48e6eb1e-b911-4530-8245-90f19c010246",
+		"message_id": "b053ce28-93a9-4028-8409-673c9d3a16b6",
+		"timestamp": "2023-01-31T08:17:19.893Z",
 		"ttl": "PT30S"
 	},
 	"message": {
 		"intent": {
 			"item": {
 				"descriptor": {
-					"name": "watermelon fruits and vegetables"
+					"name": "watermelon"
 				}
 			},
 			"fulfillment": {

--- a/logs/Nearshop/select.json
+++ b/logs/Nearshop/select.json
@@ -9,9 +9,9 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "2dcdb2af-b174-404b-96a4-263d9f1d6971",
-        "timestamp": "2023-01-30T15:32:21.084Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "4222cd0c-53d9-4623-8832-f0a9a0526654",
+        "timestamp": "2023-01-31T08:51:25.960Z",
         "ttl": "PT30S"
     },
     "message": {

--- a/logs/Nearshop/status.json
+++ b/logs/Nearshop/status.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "d3ec328a-3e78-4518-88c2-c309c2237c43",
-        "timestamp": "2023-01-30T15:32:58.103Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "e3ec328a-3e78-4518-88c2-c309c2237c88",
+        "timestamp": "2023-01-31T08:51:55.571Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
+        "order_id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da"
     }
 }

--- a/logs/Nearshop/support.json
+++ b/logs/Nearshop/support.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "97ce2075-4837-46fd-913a-8ef4273e4ad9",
-        "timestamp": "2023-01-30T15:33:19.358Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "a3c5878f-75f2-4884-9c7e-abcf53fa766b",
+        "timestamp": "2023-01-31T08:51:55.639Z",
         "ttl": "PT30S"
     },
     "message": {
-        "ref_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa"
+        "ref_id": "59f19f15-e78d-4a81-959f-9e916cef23b1"
     }
 }

--- a/logs/Nearshop/track.json
+++ b/logs/Nearshop/track.json
@@ -9,12 +9,12 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "f47345a7-fdd9-4aee-8851-408fc78c249c",
-        "timestamp": "2023-01-30T15:33:22.573Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "e25dbe91-a197-4dd5-9ca4-63459aff0518",
+        "timestamp": "2023-01-31T08:51:48.296Z",
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "586c7254-02f4-47d0-ab1c-6ec37df13207"
+        "order_id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da"
     }
 }

--- a/logs/Nearshop/update.json
+++ b/logs/Nearshop/update.json
@@ -9,15 +9,15 @@
         "bpp_uri": "https://api.staging.nearshop.in/bpp/api/v1",
         "bap_id": "ondc.indiastack.cloud",
         "bap_uri": "https://ondc.indiastack.cloud/ondc/v1/163525/",
-        "transaction_id": "cf16590d-f843-4922-9ce1-9dbbd178edaa",
-        "message_id": "8a1b82f9-8af0-4182-8715-9e777a5eef63",
-        "timestamp": "2023-01-30T15:33:39.746Z",
+        "transaction_id": "59f19f15-e78d-4a81-959f-9e916cef23b1",
+        "message_id": "8baf2980-68ef-425c-82a5-dae6fb144a05",
+        "timestamp": "2023-01-31T08:52:16.352Z",
         "ttl": "PT30S"
     },
     "message": {
         "update_target": "item",
         "order": {
-            "id": "586c7254-02f4-47d0-ab1c-6ec37df13207",
+            "id": "6dd9d2c0-9830-48fc-80fa-7f32740c76da",
             "state": "Accepted",
             "provider": {
                 "id": "44f1a436-8eb8-5bb7-93e7-39e2324efcb7"


### PR DESCRIPTION
**FIXED**:

/update
payment settlement_details can't be empty

/on_update
quote.breakup unit price missing
Billing object is not required
Fulfillments not required for "part cancel"

/on_cancel (Different order and txn)
Payment and billing object not required
Fulfillments[] not required if cancellation reason is not triggering RTO.

For on_cancel a separate order is created (payload_for_cancel file has its on_confirm payload.) as india stack buyer app invokes update api call again. The ONDC team has confirmed that this should be fine.