### PR TITLE
Add logs of JioMart BuyerApp flow

### DIFF
--- a/logs/JioMart/BuyerApp/Flow1/confirm.json
+++ b/logs/JioMart/BuyerApp/Flow1/confirm.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "24cc397f-1f95-453d-816a-d8777134bb2f",
+    "timestamp": "2023-03-08T09:16:52.113Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": { "phone": "7738027004" },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": {} },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "addOns": [],
+      "offers": [],
+      "payment": {
+        "params": { "amount": "680", "currency": "INR" },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP"
+      },
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/init.json
+++ b/logs/JioMart/BuyerApp/Flow1/init.json
@@ -1,0 +1,96 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "50c0d346-1b58-445b-83b7-f564d4280576",
+    "timestamp": "2023-03-08T09:12:39.931Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "add_ons": [],
+      "offers": [],
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "locality": null,
+          "ward": null,
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "areaCode": "400101",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": {
+              "email": "mohitkamble@gofynd.com",
+              "phone": "7738027004"
+            },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "locality": null,
+                "ward": null,
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "areaCode": "400101",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": { "name": "Mohit Kamble (Home)" } },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/ondc-withholding_amount": 0,
+        "@ondc/org/ondc-return_window": 0,
+        "@ondc/org/ondc-settlement_basis": "Collection",
+        "@ondc/org/ondc-settlement_window": "PT2D"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_confirm.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_confirm.json
@@ -1,0 +1,150 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "24cc397f-1f95-453d-816a-d8777134bb2f",
+    "timestamp": "2023-03-08T09:16:54.997Z"
+  },
+  "message": {
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }],
+        "rateable": true
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "descriptor": { "name": "Jajee" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee",
+          "rateable": true
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ],
+        "params": { "amount": "680", "currency": "INR" }
+      },
+      "updated_at": "2023-03-08T09:16:54.984Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_init.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_init.json
@@ -1,0 +1,130 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "50c0d346-1b58-445b-83b7-f564d4280576",
+    "timestamp": "2023-03-08T09:12:41.685Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "provider_location": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          }
+        }
+      ],
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_search.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_search.json
@@ -1,0 +1,217 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "aabcaf3f-5775-4c66-b5fe-8e017ea0ad60",
+    "timestamp": "2023-03-08T09:02:58.418Z"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "M/s Parasram Jajee",
+        "symbol": "https://img.shortlyst.com/merch/1607072148963",
+        "short_desc": "M/s Parasram Jajee",
+        "long_desc": "M/s Parasram Jajee",
+        "images": ["https://img.shortlyst.com/merch/1607072148963"]
+      },
+      "bpp/providers": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "descriptor": {
+            "name": "M/s Parasram Jajee",
+            "symbol": "https://img.shortlyst.com/merch/1607072148963",
+            "short_desc": "M/s Parasram Jajee",
+            "long_desc": "M/s Parasram Jajee",
+            "images": ["https://img.shortlyst.com/merch/1607072148963"]
+          },
+          "locations": [
+            {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "gps": "17.3371562,76.8311261",
+              "address": {
+                "street": "Saraf bazar, Gulbarga",
+                "city": "Gulbarga",
+                "state": "Karanataka",
+                "area_code": "585101"
+              },
+              "time": {
+                "range": { "start": "0000", "end": "2359" },
+                "days": "1,2,3,4,5,6,7"
+              }
+            }
+          ],
+          "items": [
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 100g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.00",
+                "maximum_value": "50.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.1 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+              "quantity": {
+                "available": { "count": "6" },
+                "maximum": { "count": "6" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 250g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.00",
+                "maximum_value": "120.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.25 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+              "quantity": {
+                "available": { "count": "10" },
+                "maximum": { "count": "10" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 500g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.00",
+                "maximum_value": "220.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.5 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+              "quantity": {
+                "available": { "count": "10" },
+                "maximum": { "count": "10" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 1kg",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "400.00",
+                "maximum_value": "440.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "1.0 kg"
+              }
+            }
+          ],
+          "fulfillments": [
+            {
+              "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+            }
+          ],
+          "@ondc/org/fssai_license_no": "11220316000279",
+          "ttl": "PT24H",
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "5692eae837b7a1d2b7ebd8e6bd251b51"
+                },
+                { "code": "category", "value": "Fruits and Vegetables" },
+                { "code": "type", "value": "12" },
+                { "code": "val", "value": "IND" },
+                { "code": "unit", "value": "country" }
+              ]
+            }
+          ],
+          "time": { "timestamp": "2023-03-08T09:02:58.418Z", "label": "enable" }
+        }
+      ],
+      "bpp/fulfillments": [{ "id": "1", "type": "Delivery" }]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_select.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_select.json
@@ -1,0 +1,99 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "6e8206ac-aa43-432e-9310-7b63e75e5290",
+    "timestamp": "2023-03-08T09:06:22.800Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": {
+              "price": { "currency": "INR", "value": "100.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": {
+              "price": { "currency": "INR", "value": "200.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": {
+              "price": { "currency": "INR", "value": "40.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_status.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_status.json
@@ -1,0 +1,133 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "e61d772a-6735-49a1-b284-922319221311",
+    "timestamp": "2023-03-08T09:20:06.627Z"
+  },
+  "message": {
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "680", "currency": "INR" }
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_status_after_update.json
@@ -1,0 +1,154 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "6a72976e-d5af-4128-984b-9316358ce078",
+    "timestamp": "2023-03-08T09:24:52.930Z"
+  },
+  "message": {
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 },
+          "tags": { "status": "Return_Initiated" }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-08T09:23:03.329Z",
+              "range": {
+                "start": "2023-03-08T09:22:03.329Z",
+                "end": "2023-03-08T09:23:03.329Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "680", "currency": "INR" }
+      },
+      "updated_at": "2023-03-08T09:23:03.329Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/on_update.json
+++ b/logs/JioMart/BuyerApp/Flow1/on_update.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "d83c7ce2-160b-47e7-a774-bd98ea25cc9f",
+    "timestamp": "2023-03-08T09:23:31.103Z"
+  },
+  "message": {
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "state": "Completed",
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 },
+          "tags": { "status": "Return_Initiated" }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "680.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "80.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-08T09:23:03.329Z",
+              "range": {
+                "start": "2023-03-08T09:22:03.329Z",
+                "end": "2023-03-08T09:23:03.329Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/search.json
+++ b/logs/JioMart/BuyerApp/Flow1/search.json
@@ -1,0 +1,27 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "aabcaf3f-5775-4c66-b5fe-8e017ea0ad60",
+    "timestamp": "2023-03-08T09:02:57.788Z"
+  },
+  "message": {
+    "intent": {
+      "item": { "descriptor": { "name": "raisin" } },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": { "location": { "gps": "19.1176,72.8692627" } }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/select.json
+++ b/logs/JioMart/BuyerApp/Flow1/select.json
@@ -1,0 +1,47 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "6e8206ac-aa43-432e-9310-7b63e75e5290",
+    "timestamp": "2023-03-08T09:06:21.974Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.1176, 72.8692627",
+              "address": { "area_code": "undefined" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow1/status.json
+++ b/logs/JioMart/BuyerApp/Flow1/status.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "e61d772a-6735-49a1-b284-922319221311",
+    "timestamp": "2023-03-08T09:20:06.318Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741" }
+}

--- a/logs/JioMart/BuyerApp/Flow1/status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow1/status_after_update.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "6a72976e-d5af-4128-984b-9316358ce078",
+    "timestamp": "2023-03-08T09:24:52.635Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741" }
+}

--- a/logs/JioMart/BuyerApp/Flow1/update.json
+++ b/logs/JioMart/BuyerApp/Flow1/update.json
@@ -1,0 +1,36 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "38a45950-973a-4614-b033-d84baf8ddf4c",
+    "message_id": "d83c7ce2-160b-47e7-a774-bd98ea25cc9f",
+    "timestamp": "2023-03-08T09:23:30.225Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "bcbc4c17-a2f1-4bb5-a546-3f033410e741",
+      "state": "Completed",
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 },
+          "tags": {
+            "update_type": "return",
+            "reason_code": "002",
+            "ttl_approval": "P7D",
+            "ttl_reverseqc": "P3D",
+            "image": ""
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/confirm.json
+++ b/logs/JioMart/BuyerApp/Flow3/confirm.json
@@ -1,0 +1,108 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "e3a6e96e-1075-4ee2-9ae8-f369a8c04aba",
+    "timestamp": "2023-03-09T07:38:48.386Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": { "phone": "7738027004" },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": {} },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "addOns": [],
+      "offers": [],
+      "payment": {
+        "params": { "amount": "1600", "currency": "INR" },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP"
+      },
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/init.json
+++ b/logs/JioMart/BuyerApp/Flow3/init.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "e94c1c3f-8ca7-496c-a422-639b37c44594",
+    "timestamp": "2023-03-09T07:37:03.799Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_confirm.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_confirm.json
@@ -1,0 +1,137 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "e3a6e96e-1075-4ee2-9ae8-f369a8c04aba",
+    "timestamp": "2023-03-09T07:38:51.378Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }],
+        "rateable": true
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "descriptor": { "name": "Jajee" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee",
+          "rateable": true
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "3",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ],
+        "params": { "amount": "1600", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:38:51.365Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_init.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_init.json
@@ -1,0 +1,81 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "e94c1c3f-8ca7-496c-a422-639b37c44594",
+    "timestamp": "2023-03-09T07:37:05.012Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": {
+              "price": { "currency": "INR", "value": "400.00" },
+              "quantity": {
+                "available": { "count": "3" },
+                "maximum": { "count": "3" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": {
+              "price": { "currency": "INR", "value": "200.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_search.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_search.json
@@ -1,0 +1,217 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "4ae187d3-ae70-4f4b-9bcd-7cae47e16457",
+    "timestamp": "2023-03-09T07:33:58.640Z"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "M/s Parasram Jajee",
+        "symbol": "https://img.shortlyst.com/merch/1607072148963",
+        "short_desc": "M/s Parasram Jajee",
+        "long_desc": "M/s Parasram Jajee",
+        "images": ["https://img.shortlyst.com/merch/1607072148963"]
+      },
+      "bpp/providers": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "descriptor": {
+            "name": "M/s Parasram Jajee",
+            "symbol": "https://img.shortlyst.com/merch/1607072148963",
+            "short_desc": "M/s Parasram Jajee",
+            "long_desc": "M/s Parasram Jajee",
+            "images": ["https://img.shortlyst.com/merch/1607072148963"]
+          },
+          "locations": [
+            {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "gps": "17.3371562,76.8311261",
+              "address": {
+                "street": "Saraf bazar, Gulbarga",
+                "city": "Gulbarga",
+                "state": "Karanataka",
+                "area_code": "585101"
+              },
+              "time": {
+                "range": { "start": "0000", "end": "2359" },
+                "days": "1,2,3,4,5,6,7"
+              }
+            }
+          ],
+          "items": [
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 100g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.00",
+                "maximum_value": "50.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.1 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+              "quantity": {
+                "available": { "count": "6" },
+                "maximum": { "count": "6" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 250g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.00",
+                "maximum_value": "120.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.25 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+              "quantity": {
+                "available": { "count": "8" },
+                "maximum": { "count": "8" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 500g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.00",
+                "maximum_value": "220.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.5 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+              "quantity": {
+                "available": { "count": "5" },
+                "maximum": { "count": "5" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 1kg",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "400.00",
+                "maximum_value": "440.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "1.0 kg"
+              }
+            }
+          ],
+          "fulfillments": [
+            {
+              "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+            }
+          ],
+          "@ondc/org/fssai_license_no": "11220316000279",
+          "ttl": "PT24H",
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "5692eae837b7a1d2b7ebd8e6bd251b51"
+                },
+                { "code": "category", "value": "Fruits and Vegetables" },
+                { "code": "type", "value": "12" },
+                { "code": "val", "value": "IND" },
+                { "code": "unit", "value": "country" }
+              ]
+            }
+          ],
+          "time": { "timestamp": "2023-03-09T07:33:58.640Z", "label": "enable" }
+        }
+      ],
+      "bpp/fulfillments": [{ "id": "1", "type": "Delivery" }]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_select.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_select.json
@@ -1,0 +1,81 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "008ac9d8-17a9-4e00-b917-cba033329999",
+    "timestamp": "2023-03-09T07:36:10.669Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": {
+              "price": { "currency": "INR", "value": "400.00" },
+              "quantity": {
+                "available": { "count": "3" },
+                "maximum": { "count": "3" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": {
+              "price": { "currency": "INR", "value": "200.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_status.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_status.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "b58dc209-f298-4db5-8b26-dbfc21e9c981",
+    "timestamp": "2023-03-09T07:40:11.968Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "1600", "currency": "INR" }
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_status_after_update.json
@@ -1,0 +1,141 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "ec2548f1-32a5-414e-b92d-58a218259b67",
+    "timestamp": "2023-03-09T07:46:19.669Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 },
+          "tags": { "status": "Return_Initiated" }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:43:46.905Z",
+              "range": {
+                "start": "2023-03-09T07:42:46.905Z",
+                "end": "2023-03-09T07:43:46.905Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "1600", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:43:46.905Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_status_completed.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_status_completed.json
@@ -1,0 +1,141 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "525e0875-d45a-4ae2-95df-4f39db6c7b94",
+    "timestamp": "2023-03-09T07:43:46.925Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:43:46.905Z",
+              "range": {
+                "start": "2023-03-09T07:42:46.905Z",
+                "end": "2023-03-09T07:43:46.905Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "1600", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:43:46.905Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_status_in_progress.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_status_in_progress.json
@@ -1,0 +1,127 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "898a9f2a-2c53-4478-82cb-493963faed98",
+    "timestamp": "2023-03-09T07:41:27.967Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "In-progress",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Packed" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "1600", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:41:27.946Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_status_seller_reject.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_status_seller_reject.json
@@ -1,0 +1,141 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "2918f4ad-7547-4ac4-b0dc-ab245a6bab33",
+    "timestamp": "2023-03-09T07:58:55.201Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 },
+          "tags": { "status": "Return_Rejected" }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:43:46.905Z",
+              "range": {
+                "start": "2023-03-09T07:42:46.905Z",
+                "end": "2023-03-09T07:43:46.905Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "1600", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:43:46.905Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/on_update.json
+++ b/logs/JioMart/BuyerApp/Flow3/on_update.json
@@ -1,0 +1,107 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "f6417b2c-9b0a-4848-82af-1c709d304c32",
+    "timestamp": "2023-03-09T07:46:02.982Z"
+  },
+  "message": {
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Completed",
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 },
+          "tags": { "status": "Return_Initiated" }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "1600.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 1kg",
+            "price": { "currency": "INR", "value": "1200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+            "item": { "price": { "currency": "INR", "value": "400.00" } },
+            "@ondc/org/item_quantity": { "count": 3 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:43:46.905Z",
+              "range": {
+                "start": "2023-03-09T07:42:46.905Z",
+                "end": "2023-03-09T07:43:46.905Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/search.json
+++ b/logs/JioMart/BuyerApp/Flow3/search.json
@@ -1,0 +1,27 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "4ae187d3-ae70-4f4b-9bcd-7cae47e16457",
+    "timestamp": "2023-03-09T07:33:58.278Z"
+  },
+  "message": {
+    "intent": {
+      "item": { "descriptor": { "name": "raisins" } },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": { "location": { "gps": "12.955106,77.6593211" } }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/select.json
+++ b/logs/JioMart/BuyerApp/Flow3/select.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "008ac9d8-17a9-4e00-b917-cba033329999",
+    "timestamp": "2023-03-09T07:36:09.218Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+          "quantity": { "count": 3 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow3/status.json
+++ b/logs/JioMart/BuyerApp/Flow3/status.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "b58dc209-f298-4db5-8b26-dbfc21e9c981",
+    "timestamp": "2023-03-09T07:40:11.471Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e" }
+}

--- a/logs/JioMart/BuyerApp/Flow3/status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow3/status_after_update.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "ec2548f1-32a5-414e-b92d-58a218259b67",
+    "timestamp": "2023-03-09T07:46:19.252Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e" }
+}

--- a/logs/JioMart/BuyerApp/Flow3/update.json
+++ b/logs/JioMart/BuyerApp/Flow3/update.json
@@ -1,0 +1,36 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "ce7dc990-2615-451a-b315-07758b2d604d",
+    "message_id": "f6417b2c-9b0a-4848-82af-1c709d304c32",
+    "timestamp": "2023-03-09T07:46:02.112Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "7abdb6d3-c413-43a9-a2b7-e0ae4e172e8e",
+      "state": "Completed",
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 },
+          "tags": {
+            "update_type": "return",
+            "reason_code": "001",
+            "ttl_approval": "P7D",
+            "ttl_reverseqc": "P3D",
+            "image": ""
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/confirm.json
+++ b/logs/JioMart/BuyerApp/Flow4/confirm.json
@@ -1,0 +1,108 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "88a3aefe-99a7-444a-9bb3-23912d6b7048",
+    "timestamp": "2023-03-09T07:13:24.281Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": { "phone": "7738027004" },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": {} },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "addOns": [],
+      "offers": [],
+      "payment": {
+        "params": { "amount": "380", "currency": "INR" },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP"
+      },
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/init.json
+++ b/logs/JioMart/BuyerApp/Flow4/init.json
@@ -1,0 +1,92 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "3008fd17-45b1-40c6-b068-97a62c4bbb16",
+    "timestamp": "2023-03-09T07:10:13.543Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "add_ons": [],
+      "offers": [],
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "locality": null,
+          "ward": null,
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "areaCode": "400101",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": {
+              "email": "mohitkamble@gofynd.com",
+              "phone": "7738027004"
+            },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "locality": null,
+                "ward": null,
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "areaCode": "400101",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": { "name": "Mohit Kamble (Home)" } },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/ondc-withholding_amount": 0,
+        "@ondc/org/ondc-return_window": 0,
+        "@ondc/org/ondc-settlement_basis": "Collection",
+        "@ondc/org/ondc-settlement_window": "PT2D"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_confirm.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_confirm.json
@@ -1,0 +1,137 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "88a3aefe-99a7-444a-9bb3-23912d6b7048",
+    "timestamp": "2023-03-09T07:13:26.986Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }],
+        "rateable": true
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "descriptor": { "name": "Jajee" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee",
+          "rateable": true
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ],
+        "params": { "amount": "380", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:13:26.972Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_init.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_init.json
@@ -1,0 +1,117 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "3008fd17-45b1-40c6-b068-97a62c4bbb16",
+    "timestamp": "2023-03-09T07:10:15.335Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "provider_location": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          }
+        }
+      ],
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_search.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_search.json
@@ -1,0 +1,217 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "8a8d07cb-e86f-4378-8be0-750b0650a48d",
+    "timestamp": "2023-03-09T07:04:20.931Z"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "M/s Parasram Jajee",
+        "symbol": "https://img.shortlyst.com/merch/1607072148963",
+        "short_desc": "M/s Parasram Jajee",
+        "long_desc": "M/s Parasram Jajee",
+        "images": ["https://img.shortlyst.com/merch/1607072148963"]
+      },
+      "bpp/providers": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "descriptor": {
+            "name": "M/s Parasram Jajee",
+            "symbol": "https://img.shortlyst.com/merch/1607072148963",
+            "short_desc": "M/s Parasram Jajee",
+            "long_desc": "M/s Parasram Jajee",
+            "images": ["https://img.shortlyst.com/merch/1607072148963"]
+          },
+          "locations": [
+            {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "gps": "17.3371562,76.8311261",
+              "address": {
+                "street": "Saraf bazar, Gulbarga",
+                "city": "Gulbarga",
+                "state": "Karanataka",
+                "area_code": "585101"
+              },
+              "time": {
+                "range": { "start": "0000", "end": "2359" },
+                "days": "1,2,3,4,5,6,7"
+              }
+            }
+          ],
+          "items": [
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 100g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.00",
+                "maximum_value": "50.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.1 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+              "quantity": {
+                "available": { "count": "6" },
+                "maximum": { "count": "6" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 250g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.00",
+                "maximum_value": "120.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.25 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+              "quantity": {
+                "available": { "count": "8" },
+                "maximum": { "count": "8" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 500g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.00",
+                "maximum_value": "220.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.5 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+              "quantity": {
+                "available": { "count": "5" },
+                "maximum": { "count": "5" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 1kg",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "400.00",
+                "maximum_value": "440.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "1.0 kg"
+              }
+            }
+          ],
+          "fulfillments": [
+            {
+              "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+            }
+          ],
+          "@ondc/org/fssai_license_no": "11220316000279",
+          "ttl": "PT24H",
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "5692eae837b7a1d2b7ebd8e6bd251b51"
+                },
+                { "code": "category", "value": "Fruits and Vegetables" },
+                { "code": "type", "value": "12" },
+                { "code": "val", "value": "IND" },
+                { "code": "unit", "value": "country" }
+              ]
+            }
+          ],
+          "time": { "timestamp": "2023-03-09T07:04:20.931Z", "label": "enable" }
+        }
+      ],
+      "bpp/fulfillments": [{ "id": "1", "type": "Delivery" }]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_select.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_select.json
@@ -1,0 +1,82 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "40923f67-c763-42c9-b753-327f75ffaf1f",
+    "timestamp": "2023-03-09T07:06:51.673Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": {
+              "price": { "currency": "INR", "value": "40.00" },
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": {
+              "price": { "currency": "INR", "value": "100.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  },
+  "error": { "type": "DOMAIN-ERROR", "code": "40002" }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_select_updated.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_select_updated.json
@@ -1,0 +1,81 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "232e5f07-f483-40f9-854d-6118b3413c8e",
+    "timestamp": "2023-03-09T07:08:50.655Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": {
+              "price": { "currency": "INR", "value": "40.00" },
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": {
+              "price": { "currency": "INR", "value": "100.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_status.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_status.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "2ce23ac2-3d62-4d18-9549-a37d6ef2feb4",
+    "timestamp": "2023-03-09T07:17:30.568Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "380", "currency": "INR" }
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_status_after_update.json
@@ -1,0 +1,141 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "97edadd8-175a-4eac-9315-148027b1868a",
+    "timestamp": "2023-03-09T07:27:35.247Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 },
+          "tags": { "status": "Return_Initiated" }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:20:44.323Z",
+              "range": {
+                "start": "2023-03-09T07:19:44.323Z",
+                "end": "2023-03-09T07:20:44.323Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "380", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:20:44.323Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_status_completed.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_status_completed.json
@@ -1,0 +1,141 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "5c67c45d-8242-413d-b394-742226497b27",
+    "timestamp": "2023-03-09T07:20:44.344Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:20:44.323Z",
+              "range": {
+                "start": "2023-03-09T07:19:44.323Z",
+                "end": "2023-03-09T07:20:44.323Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "380", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:20:44.323Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_status_in_progress.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_status_in_progress.json
@@ -1,0 +1,127 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "83675d1d-5a60-44f0-adbd-43fd41f82005",
+    "timestamp": "2023-03-09T07:19:41.451Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "In-progress",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Packed" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "380", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:19:41.430Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_status_seller_approve.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_status_seller_approve.json
@@ -1,0 +1,133 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "4b79d139-6120-49d3-8f4d-f94e92562f94",
+    "timestamp": "2023-03-09T07:58:31.590Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Completed",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 },
+          "tags": { "status": "Liquidated" }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "220.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "documents": [
+        {
+          "url": "https://static.shopalyst.com/assets/campaigns/invoice_jajee.jpeg",
+          "label": "Invoice"
+        }
+      ],
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:58:31.568Z",
+              "range": {
+                "start": "2023-03-09T07:57:31.568Z",
+                "end": "2023-03-09T07:58:31.568Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "380", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T07:58:31.568Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/on_update.json
+++ b/logs/JioMart/BuyerApp/Flow4/on_update.json
@@ -1,0 +1,107 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "ea855494-915a-4360-9cd0-5e919a3da10d",
+    "timestamp": "2023-03-09T07:23:09.430Z"
+  },
+  "message": {
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Completed",
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 },
+          "tags": { "status": "Return_Initiated" }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "380.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 250g",
+            "price": { "currency": "INR", "value": "200.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+            "item": { "price": { "currency": "INR", "value": "100.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "20.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ]
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "time": {
+              "timestamp": "0001-01-01T00:00:00.000Z",
+              "range": {
+                "start": "0001-01-01T00:00:00.000Z",
+                "end": "0001-01-01T00:00:00.000Z"
+              }
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "time": {
+              "timestamp": "2023-03-09T07:20:44.323Z",
+              "range": {
+                "start": "2023-03-09T07:19:44.323Z",
+                "end": "2023-03-09T07:20:44.323Z"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Order-delivered" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/search.json
+++ b/logs/JioMart/BuyerApp/Flow4/search.json
@@ -1,0 +1,27 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "8a8d07cb-e86f-4378-8be0-750b0650a48d",
+    "timestamp": "2023-03-09T07:04:16.918Z"
+  },
+  "message": {
+    "intent": {
+      "item": { "descriptor": { "name": "raisins" } },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": { "location": { "gps": "19.2053788,72.8716305" } }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/select.json
+++ b/logs/JioMart/BuyerApp/Flow4/select.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "40923f67-c763-42c9-b753-327f75ffaf1f",
+    "timestamp": "2023-03-09T07:06:50.403Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 5 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2053788, 72.8716305",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/select_updated.json
+++ b/logs/JioMart/BuyerApp/Flow4/select_updated.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "232e5f07-f483-40f9-854d-6118b3413c8e",
+    "timestamp": "2023-03-09T07:08:49.620Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2053788, 72.8716305",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow4/status.json
+++ b/logs/JioMart/BuyerApp/Flow4/status.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "2ce23ac2-3d62-4d18-9549-a37d6ef2feb4",
+    "timestamp": "2023-03-09T07:17:30.129Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "c0afe008-c803-44f6-b2aa-5601632910e4" }
+}

--- a/logs/JioMart/BuyerApp/Flow4/status_after_update.json
+++ b/logs/JioMart/BuyerApp/Flow4/status_after_update.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "97edadd8-175a-4eac-9315-148027b1868a",
+    "timestamp": "2023-03-09T07:27:34.801Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "c0afe008-c803-44f6-b2aa-5601632910e4" }
+}

--- a/logs/JioMart/BuyerApp/Flow4/update.json
+++ b/logs/JioMart/BuyerApp/Flow4/update.json
@@ -1,0 +1,36 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "update",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "9f5c8801-f121-4d47-8890-f348e233c059",
+    "message_id": "ea855494-915a-4360-9cd0-5e919a3da10d",
+    "timestamp": "2023-03-09T07:23:08.304Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "update_target": "item",
+    "order": {
+      "id": "c0afe008-c803-44f6-b2aa-5601632910e4",
+      "state": "Completed",
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 },
+          "tags": {
+            "update_type": "return",
+            "reason_code": "001",
+            "ttl_approval": "P7D",
+            "ttl_reverseqc": "P3D",
+            "image": ""
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/cancle.json
+++ b/logs/JioMart/BuyerApp/Flow5/cancle.json
@@ -1,0 +1,19 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "cancel",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "39b874d7-bcd0-4816-b950-e66f1ec44d80",
+    "timestamp": "2023-03-09T08:16:43.433Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order_id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+    "cancellation_reason_id": "001"
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/confirm.json
+++ b/logs/JioMart/BuyerApp/Flow5/confirm.json
@@ -1,0 +1,108 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "fa543943-2a90-40b0-bc82-e1ebfcdd56b6",
+    "timestamp": "2023-03-09T08:13:24.273Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": { "phone": "7738027004" },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": {} },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "addOns": [],
+      "offers": [],
+      "payment": {
+        "params": { "amount": "560", "currency": "INR" },
+        "status": "PAID",
+        "type": "ON-ORDER",
+        "collected_by": "BAP"
+      },
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/init.json
+++ b/logs/JioMart/BuyerApp/Flow5/init.json
@@ -1,0 +1,92 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "fce4727c-52b1-4786-bcae-b19275338416",
+    "timestamp": "2023-03-09T08:11:54.418Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "add_ons": [],
+      "offers": [],
+      "billing": {
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "locality": null,
+          "ward": null,
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "areaCode": "400101",
+          "area_code": "400101"
+        },
+        "phone": "7738027004",
+        "name": "Mohit Kamble (Home)",
+        "email": "mohitkamble@gofynd.com"
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "contact": {
+              "email": "mohitkamble@gofynd.com",
+              "phone": "7738027004"
+            },
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "locality": null,
+                "ward": null,
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "areaCode": "400101",
+                "area_code": "400101"
+              }
+            }
+          },
+          "type": "Delivery",
+          "customer": { "person": { "name": "Mohit Kamble (Home)" } },
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/ondc-withholding_amount": 0,
+        "@ondc/org/ondc-return_window": 0,
+        "@ondc/org/ondc-settlement_basis": "Collection",
+        "@ondc/org/ondc-settlement_window": "PT2D"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_cancle.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_cancle.json
@@ -1,0 +1,23 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_cancel",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "39b874d7-bcd0-4816-b950-e66f1ec44d80",
+    "timestamp": "2023-03-09T08:16:44.446Z"
+  },
+  "message": {
+    "order": {
+      "id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+      "state": "Cancelled",
+      "tags": { "cancellation_reason_id": "001" }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_confirm.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_confirm.json
@@ -1,0 +1,137 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_confirm",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "fa543943-2a90-40b0-bc82-e1ebfcdd56b6",
+    "timestamp": "2023-03-09T08:13:27.271Z"
+  },
+  "message": {
+    "order": {
+      "id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }],
+        "rateable": true
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "descriptor": { "name": "Jajee" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee",
+          "rateable": true
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ],
+        "params": { "amount": "560", "currency": "INR" }
+      },
+      "updated_at": "2023-03-09T08:13:27.236Z"
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_init.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_init.json
@@ -1,0 +1,117 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_init",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "fce4727c-52b1-4786-bcae-b19275338416",
+    "timestamp": "2023-03-09T08:11:56.048Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "provider_location": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "provider_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          }
+        }
+      ],
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2",
+        "@ondc/org/settlement_details": [
+          {
+            "settlement_counterparty": "seller-app",
+            "settlement_phase": "sale-amount",
+            "settlement_type": "neft",
+            "settlement_bank_account_no": "1112220032274181",
+            "settlement_ifsc_code": "RAZR0000001",
+            "beneficiary_name": "Kishor",
+            "bank_name": "sate bank of india",
+            "branch_name": "manikonda"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_search.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_search.json
@@ -1,0 +1,217 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "471c5156-10e2-4592-a4a5-555b784cc8cf",
+    "timestamp": "2023-03-09T08:06:36.213Z"
+  },
+  "message": {
+    "catalog": {
+      "bpp/descriptor": {
+        "name": "M/s Parasram Jajee",
+        "symbol": "https://img.shortlyst.com/merch/1607072148963",
+        "short_desc": "M/s Parasram Jajee",
+        "long_desc": "M/s Parasram Jajee",
+        "images": ["https://img.shortlyst.com/merch/1607072148963"]
+      },
+      "bpp/providers": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "descriptor": {
+            "name": "M/s Parasram Jajee",
+            "symbol": "https://img.shortlyst.com/merch/1607072148963",
+            "short_desc": "M/s Parasram Jajee",
+            "long_desc": "M/s Parasram Jajee",
+            "images": ["https://img.shortlyst.com/merch/1607072148963"]
+          },
+          "locations": [
+            {
+              "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "gps": "17.3371562,76.8311261",
+              "address": {
+                "street": "Saraf bazar, Gulbarga",
+                "city": "Gulbarga",
+                "state": "Karanataka",
+                "area_code": "585101"
+              },
+              "time": {
+                "range": { "start": "0000", "end": "2359" },
+                "days": "1,2,3,4,5,6,7"
+              }
+            }
+          ],
+          "items": [
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 100g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "40.00",
+                "maximum_value": "50.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.1 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043628803_default",
+              "quantity": {
+                "available": { "count": "6" },
+                "maximum": { "count": "6" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 250g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "100.00",
+                "maximum_value": "120.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.25 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+              "quantity": {
+                "available": { "count": "8" },
+                "maximum": { "count": "8" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 500g",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "200.00",
+                "maximum_value": "220.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "0.5 kg"
+              }
+            },
+            {
+              "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043694339_default",
+              "quantity": {
+                "available": { "count": "5" },
+                "maximum": { "count": "5" }
+              },
+              "descriptor": {
+                "name": "RAISINS/KHISMISH/MANUKKA 1kg",
+                "symbol": "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770",
+                "short_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "long_desc": "A raisin is a dried grape. Raisins are produced in many regions of the world and may be eaten raw or used in cooking, baking, and brewing. Rich in fiber, vitamins, minerals, polyphenol antioxidents. These are used in preparation of sweets, cakes, cooking and deserts.",
+                "images": [
+                  "https://imgcdn.shortlyst.com/?u=https%3A%2F%2Fcdn.shopify.com%2Fs%2Ffiles%2F1%2F0661%2F9732%2F4035%2Fproducts%2Fraisins_95747b37-7d71-41ed-b08d-b93ee642864a.jpg%3Fv%3D1669092770"
+                ]
+              },
+              "price": {
+                "currency": "INR",
+                "value": "400.00",
+                "maximum_value": "440.00"
+              },
+              "category_id": "Fruits and Vegetables",
+              "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "location_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+              "@ondc/org/returnable": true,
+              "@ondc/org/seller_pickup_return": true,
+              "@ondc/org/return_window": "P7D",
+              "@ondc/org/cancellable": true,
+              "@ondc/org/time_to_ship": "P3D",
+              "@ondc/org/available_on_cod": false,
+              "@ondc/org/contact_details_consumer_care": "M/s Parasram Jajee,support@jajee.in,+919164607070",
+              "@ondc/org/mandatory_reqs_veggies_fruits": {
+                "net_quantity": "1.0 kg"
+              }
+            }
+          ],
+          "fulfillments": [
+            {
+              "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+            }
+          ],
+          "@ondc/org/fssai_license_no": "11220316000279",
+          "ttl": "PT24H",
+          "tags": [
+            {
+              "code": "serviceability",
+              "list": [
+                {
+                  "code": "location",
+                  "value": "5692eae837b7a1d2b7ebd8e6bd251b51"
+                },
+                { "code": "category", "value": "Fruits and Vegetables" },
+                { "code": "type", "value": "12" },
+                { "code": "val", "value": "IND" },
+                { "code": "unit", "value": "country" }
+              ]
+            }
+          ],
+          "time": { "timestamp": "2023-03-09T08:06:36.213Z", "label": "enable" }
+        }
+      ],
+      "bpp/fulfillments": [{ "id": "1", "type": "Delivery" }]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_select.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_select.json
@@ -1,0 +1,82 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "d846c358-5234-40db-9f09-44f7097c86e1",
+    "timestamp": "2023-03-09T08:08:26.225Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": {
+              "price": { "currency": "INR", "value": "40.00" },
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": {
+              "price": { "currency": "INR", "value": "200.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  },
+  "error": { "type": "DOMAIN-ERROR", "code": "40002" }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_select_updated.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_select_updated.json
@@ -1,0 +1,81 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "56cc583c-8b96-4de8-b432-786c1547f640",
+    "timestamp": "2023-03-09T08:10:35.333Z"
+  },
+  "message": {
+    "order": {
+      "provider": { "id": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51"
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": {
+              "price": { "currency": "INR", "value": "40.00" },
+              "quantity": {
+                "available": { "count": "4" },
+                "maximum": { "count": "4" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.0" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": {
+              "price": { "currency": "INR", "value": "200.00" },
+              "quantity": {
+                "available": { "count": "2" },
+                "maximum": { "count": "2" }
+              }
+            },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "PT15M"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "tracking": true,
+          "state": { "descriptor": { "code": "Serviceable" } },
+          "@ondc/org/category": "Standard Delivery",
+          "@ondc/org/TAT": "P3D",
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_status.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_status.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "462b0265-d1cc-439d-a776-43791e8768fc",
+    "timestamp": "2023-03-09T08:14:20.568Z"
+  },
+  "message": {
+    "order": {
+      "id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+      "state": "Accepted",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Pending" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "560", "currency": "INR" }
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/on_status_after_cancel.json
+++ b/logs/JioMart/BuyerApp/Flow5/on_status_after_cancel.json
@@ -1,0 +1,120 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "on_status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com",
+    "bpp_uri": "https://preprod-jajee-bpp.shopalyst.com/jajee",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "7dcc72f2-cb0f-447b-bb43-1456c8c354f3",
+    "timestamp": "2023-03-09T08:19:52.068Z"
+  },
+  "message": {
+    "order": {
+      "id": "81c6c216-e5aa-4c41-9322-156716fa9d7b",
+      "state": "Cancelled",
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "fulfillment_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "quote": {
+        "price": { "currency": "INR", "value": "560.00" },
+        "breakup": [
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 100g",
+            "price": { "currency": "INR", "value": "160.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+            "item": { "price": { "currency": "INR", "value": "40.00" } },
+            "@ondc/org/item_quantity": { "count": 4 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "RAISINS/KHISMISH/MANUKKA - 500g",
+            "price": { "currency": "INR", "value": "400.00" },
+            "@ondc/org/item_id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+            "item": { "price": { "currency": "INR", "value": "200.00" } },
+            "@ondc/org/item_quantity": { "count": 2 },
+            "@ondc/org/title_type": "item"
+          },
+          {
+            "title": "Delivery Charges",
+            "price": { "currency": "INR", "value": "0.00" },
+            "@ondc/org/item_id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+            "@ondc/org/title_type": "delivery"
+          }
+        ],
+        "ttl": "P1D"
+      },
+      "billing": {
+        "name": "Mohit Kamble (Home)",
+        "address": {
+          "door": "Near Thakur College",
+          "name": "Mohit Kamble (Home)",
+          "building": "Near Thakur College",
+          "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+          "city": "Konkan Division",
+          "state": "Maharashtra",
+          "country": "IND",
+          "area_code": "400101"
+        },
+        "email": "mohitkamble@gofynd.com",
+        "phone": "7738027004"
+      },
+      "fulfillments": [
+        {
+          "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+          "type": "Delivery",
+          "tracking": true,
+          "start": {
+            "location": {
+              "descriptor": { "name": "5692eae837b7a1d2b7ebd8e6bd251b51" },
+              "gps": "17.3371562,76.8311261"
+            },
+            "contact": { "phone": "9164607070", "email": "support@jajee.in" }
+          },
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": {
+                "door": "Near Thakur College",
+                "name": "Mohit Kamble (Home)",
+                "building": "Near Thakur College",
+                "street": "E-1902, Sarova Park, Samta Nagar, Kandivali(E)",
+                "city": "Konkan Division",
+                "state": "Maharashtra",
+                "country": "IND",
+                "area_code": "400101"
+              }
+            },
+            "contact": { "phone": "7738027004" }
+          },
+          "state": { "descriptor": { "code": "Cancelled" } },
+          "@ondc/org/provider_name": "Jajee"
+        }
+      ],
+      "payment": {
+        "type": "ON-ORDER",
+        "status": "PAID",
+        "collected_by": "BAP",
+        "@ondc/org/buyer_app_finder_fee_amount": "",
+        "params": { "amount": "560", "currency": "INR" }
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/search.json
+++ b/logs/JioMart/BuyerApp/Flow5/search.json
@@ -1,0 +1,27 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "search",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "471c5156-10e2-4592-a4a5-555b784cc8cf",
+    "timestamp": "2023-03-09T08:06:35.388Z"
+  },
+  "message": {
+    "intent": {
+      "item": { "descriptor": { "name": "raisins" } },
+      "fulfillment": {
+        "type": "Delivery",
+        "end": { "location": { "gps": "19.2053788,72.8716305" } }
+      },
+      "payment": {
+        "@ondc/org/buyer_app_finder_fee_type": "Percent",
+        "@ondc/org/buyer_app_finder_fee_amount": "2"
+      }
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/select.json
+++ b/logs/JioMart/BuyerApp/Flow5/select.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "d846c358-5234-40db-9f09-44f7097c86e1",
+    "timestamp": "2023-03-09T08:08:25.114Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 5 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/select_updated.json
+++ b/logs/JioMart/BuyerApp/Flow5/select_updated.json
@@ -1,0 +1,43 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "select",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "56cc583c-8b96-4de8-b432-786c1547f640",
+    "timestamp": "2023-03-09T08:10:34.146Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": {
+    "order": {
+      "items": [
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043596035_default",
+          "quantity": { "count": 4 }
+        },
+        {
+          "id": "55EA20538A3151ABD81510BBB42C9CE3_43540043661571_default",
+          "quantity": { "count": 2 }
+        }
+      ],
+      "provider": {
+        "id": "5692eae837b7a1d2b7ebd8e6bd251b51",
+        "locations": [{ "id": "5692eae837b7a1d2b7ebd8e6bd251b51" }]
+      },
+      "fulfillments": [
+        {
+          "end": {
+            "location": {
+              "gps": "19.2058593, 72.86612",
+              "address": { "area_code": "400101" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/logs/JioMart/BuyerApp/Flow5/status.json
+++ b/logs/JioMart/BuyerApp/Flow5/status.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "462b0265-d1cc-439d-a776-43791e8768fc",
+    "timestamp": "2023-03-09T08:14:20.285Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "81c6c216-e5aa-4c41-9322-156716fa9d7b" }
+}

--- a/logs/JioMart/BuyerApp/Flow5/status_after_cancel.json
+++ b/logs/JioMart/BuyerApp/Flow5/status_after_cancel.json
@@ -1,0 +1,16 @@
+{
+  "context": {
+    "domain": "nic2004:52110",
+    "country": "IND",
+    "city": "*",
+    "action": "status",
+    "core_version": "1.1.0",
+    "bap_id": "jiomart-buyer.ondcz5.de",
+    "bap_uri": "https://jiomart-buyer.ondcz5.de/protocol/v1",
+    "transaction_id": "a008c07b-9104-4db8-9cce-53fba91241a5",
+    "message_id": "7dcc72f2-cb0f-447b-bb43-1456c8c354f3",
+    "timestamp": "2023-03-09T08:19:51.797Z",
+    "bpp_id": "preprod-jajee-bpp.shopalyst.com"
+  },
+  "message": { "order_id": "81c6c216-e5aa-4c41-9322-156716fa9d7b" }
+}


### PR DESCRIPTION
Hello team,
Please find our logs as per the requirement.
The following pointers aren’t in the logs from our Buyer App side, which we wanted to highlight:
- The combination of pincode where Seller App is serviceable for one while not serviceable for another. Need ONDC helps to align Seller App accordingly.
- Cancel / Return at item quantity level: We haven’t given a provision to raise a cancel or return request at ‘’Quantity’' level. That is planned in our next release.