### PR TITLE
Rapidor Logs: Changes Made for ONDC - 25/04/2023 Suggestions

### DIFF
--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "confirm",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "xPCSlSALd-UGBmaiTYwcK",
-        "timestamp": "2023-04-23T14:12:56.976Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "nVCeMrWVUUlaCfE3aQVv9",
+        "timestamp": "2023-04-25T05:06:50.565Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -28,8 +28,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:12:15.000Z",
-                "updated_at": "2023-04-23T14:12:15.000Z"
+                "created_at": "2023-04-25T05:05:36.000Z",
+                "updated_at": "2023-04-25T05:05:36.000Z"
             },
             "fulfillments": [
                 {
@@ -58,7 +58,7 @@
                     "tracking": false
                 }
             ],
-            "id": "RAP-0000352",
+            "id": "RAP-0000361",
             "state": "Created",
             "provider": {
                 "id": "abadfoodslive",
@@ -70,7 +70,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -85,8 +85,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_9cv5hGeYhiz6wOvPhUBh",
-                    "amount": "802.39"
+                    "transaction_id": "nvLaDOCwh1jahZOFVJXEr",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
@@ -94,12 +94,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -107,17 +107,17 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 0
@@ -125,6 +125,7 @@
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -137,12 +138,12 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
-            "created_at": "2023-04-23T14:12:56.980Z",
-            "updated_at": "2023-04-23T14:12:56.980Z"
+            "created_at": "2023-04-25T05:06:50.568Z",
+            "updated_at": "2023-04-25T05:06:50.568Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/init.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "init",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "v1pmOHcdYNksH3OmI0Zm0",
-        "timestamp": "2023-04-23T14:12:15.000Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "qljzLDRdE0GiXlTqZViUj",
+        "timestamp": "2023-04-25T05:05:36.000Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -49,7 +49,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -68,8 +68,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:12:15.000Z",
-                "updated_at": "2023-04-23T14:12:15.000Z",
+                "created_at": "2023-04-25T05:05:36.000Z",
+                "updated_at": "2023-04-25T05:05:36.000Z",
                 "tax_number": "07AABCB2115P1ZR"
             }
         }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_cancel.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_cancel.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_cancel",
         "core_version": "2.0.0",
-        "transaction_id": "RAP-0000352",
-        "message_id": "gmflX_856BDuQDbiwT1qW",
-        "timestamp": "2023-04-23T14:20:55.809Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "kHgGLIjt6es9NMH-uDGvZ",
+        "timestamp": "2023-04-25T05:08:13.632Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,10 +16,10 @@
     },
     "message": {
         "order": {
-            "id": "06dBlqeLGbUkJ43uTdJnc",
+            "id": "RAP-0000361",
             "state": "Cancelled",
             "tags": {
-                "cancellation_reason_id": "002"
+                "cancellation_reason_id": "005"
             }
         }
     }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_confirm",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "xPCSlSALd-UGBmaiTYwcK",
-        "timestamp": "2023-04-23T14:12:58.487Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "nVCeMrWVUUlaCfE3aQVv9",
+        "timestamp": "2023-04-25T05:06:52.856Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,7 +16,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000352",
+            "id": "RAP-0000361",
             "provider": {
                 "id": "abadfoodslive",
                 "locations": [
@@ -28,7 +28,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -47,8 +47,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:12:15.000Z",
-                "updated_at": "2023-04-23T14:12:15.000Z"
+                "created_at": "2023-04-25T05:05:36.000Z",
+                "updated_at": "2023-04-25T05:05:36.000Z"
             },
             "fulfillments": [
                 {
@@ -68,14 +68,14 @@
                                 "images": [
                                     "https://www.rapidor.co/wp-content/uploads/2023/02/Logo.svg"
                                 ],
-                                "name": "ABAD FOODS"
+                                "name": "Abad Foods"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:12:58.000Z",
-                                "end": "2023-04-23T16:12:58.000Z"
+                                "start": "2023-04-25T05:06:52.000Z",
+                                "end": "2023-04-25T07:06:52.000Z"
                             }
                         },
                         "contact": {
@@ -97,8 +97,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:12:58.000Z",
-                                "end": "2023-04-25T16:12:58.000Z"
+                                "start": "2023-04-27T05:06:52.000Z",
+                                "end": "2023-04-27T07:06:52.000Z"
                             }
                         },
                         "contact": {
@@ -110,12 +110,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -123,21 +123,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -147,7 +148,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
@@ -159,21 +160,15 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_9cv5hGeYhiz6wOvPhUBh",
-                    "amount": "802.39"
+                    "transaction_id": "nvLaDOCwh1jahZOFVJXEr",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
             },
             "state": "Created",
-            "documents": [
-                {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000352.pdf?v=1682259180",
-                    "label": "Order Note"
-                }
-            ],
-            "created_at": "2023-04-23T14:12:56.980Z",
-            "updated_at": "2023-04-23T14:12:58.487Z"
+            "created_at": "2023-04-25T05:06:50.568Z",
+            "updated_at": "2023-04-25T05:06:52.856Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_init.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "on_init",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "v1pmOHcdYNksH3OmI0Zm0",
-        "timestamp": "2023-04-23T14:12:17.234Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "qljzLDRdE0GiXlTqZViUj",
+        "timestamp": "2023-04-25T05:05:38.020Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -25,7 +24,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -44,8 +43,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:12:15.000Z",
-                "updated_at": "2023-04-23T14:12:15.000Z"
+                "created_at": "2023-04-25T05:05:36.000Z",
+                "updated_at": "2023-04-25T05:05:36.000Z"
             },
             "fulfillments": [
                 {
@@ -74,12 +73,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -87,21 +86,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -111,7 +111,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_search.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_search",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "lBnMNi_hNJehc7rvzLgcR",
-        "timestamp": "2023-04-23T14:08:41.009Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "qGd-H_ihfUO6j005qA-M8",
+        "timestamp": "2023-04-25T05:00:12.061Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -30,7 +30,7 @@
                 {
                     "id": "abadfoodslive",
                     "descriptor": {
-                        "name": "ABAD FOODS",
+                        "name": "Abad Foods",
                         "code": "abadfoodslive",
                         "short_desc": "PlaceOrder",
                         "long_desc": "PlaceOrder",
@@ -44,8 +44,8 @@
                         {
                             "id": "L1",
                             "area_code": "560001",
-                            "gps": "12.971600,77.594600",
-                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
+                            "gps": "12.998115,77.629250",
+                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
                             "city": {
                                 "name": "Bangalore",
                                 "code": "std:080"
@@ -55,7 +55,7 @@
                                 "code": "KA"
                             },
                             "country": {
-                                "name": "INDIA",
+                                "name": "India",
                                 "code": "IND"
                             }
                         }
@@ -102,7 +102,7 @@
                                 "unitized": {
                                     "measure": {
                                         "unit": "Units",
-                                        "value": "100"
+                                        "value": "0"
                                     }
                                 }
                             },
@@ -112,7 +112,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",
@@ -162,8 +162,8 @@
                                         "return_within": "P7D",
                                         "fulfillment_managed_by": "seller",
                                         "return_location": {
-                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
-                                            "gps": "12.971600,77.594600"
+                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
+                                            "gps": "12.998115,77.629250"
                                         }
                                     }
                                 }
@@ -219,7 +219,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",
@@ -269,8 +269,8 @@
                                         "return_within": "P7D",
                                         "fulfillment_managed_by": "seller",
                                         "return_location": {
-                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
-                                            "gps": "12.971600,77.594600"
+                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
+                                            "gps": "12.998115,77.629250"
                                         }
                                     }
                                 }
@@ -296,7 +296,7 @@
                                 },
                                 {
                                     "code": "seller_id_no",
-                                    "value": "07AAGFF2194N1Z4"
+                                    "value": "29AAFCA6821M1ZB"
                                 }
                             ]
                         },

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_select.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_select",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "h_i8nrFJDGuQ4al8OKeZB",
-        "timestamp": "2023-04-23T14:11:17.796Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "KPqPoKoaTmf-MYRUOL_Hz",
+        "timestamp": "2023-04-25T05:03:07.572Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -21,7 +21,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1"
                 }
             ],
@@ -42,12 +42,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -55,7 +55,7 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             },
                             "quantity": {
                                 "available": {
@@ -69,15 +69,16 @@
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -87,7 +88,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_select_non_serviceable.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_select_non_serviceable.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_select",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "9-xafRgkzzyAMIoAk7R8d",
-        "timestamp": "2023-04-23T14:10:04.644Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "mn78REflGj6PCghB2Cvv9",
+        "timestamp": "2023-04-25T05:01:55.264Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -21,7 +21,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1"
                 }
             ],
@@ -42,12 +42,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -55,7 +55,7 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             },
                             "quantity": {
                                 "available": {
@@ -69,17 +69,17 @@
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/on_status_post_cancel.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/on_status_post_cancel.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "2o0HVIB5YAV3Tg1RGPuTA",
-        "timestamp": "2023-04-23T14:21:38.736Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "LN9lpLBM9i1ahrzdPsbIu",
+        "timestamp": "2023-04-25T05:08:59.721Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,7 +16,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000352",
+            "id": "RAP-0000361",
             "state": "Cancelled",
             "provider": {
                 "id": "abadfoodslive",
@@ -28,7 +28,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -47,8 +47,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:12:15.000Z",
-                "updated_at": "2023-04-23T14:12:15.000Z"
+                "created_at": "2023-04-25T05:05:36.000Z",
+                "updated_at": "2023-04-25T05:05:36.000Z"
             },
             "fulfillments": [
                 {
@@ -69,12 +69,12 @@
                                 ],
                                 "name": "PlaceOrder"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:12:58.000Z",
-                                "end": "2023-04-23T16:12:58.000Z"
+                                "start": "2023-04-25T05:06:52.000Z",
+                                "end": "2023-04-25T07:06:52.000Z"
                             }
                         },
                         "contact": {
@@ -96,8 +96,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:12:58.000Z",
-                                "end": "2023-04-25T16:12:58.000Z"
+                                "start": "2023-04-27T05:06:52.000Z",
+                                "end": "2023-04-27T07:06:52.000Z"
                             }
                         },
                         "contact": {
@@ -114,8 +114,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_9cv5hGeYhiz6wOvPhUBh",
-                    "amount": "802.39"
+                    "transaction_id": "nvLaDOCwh1jahZOFVJXEr",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -123,12 +123,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -136,21 +136,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -160,20 +161,14 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
-            "documents": [
-                {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000352.pdf?v=1682259180",
-                    "label": "Order Note"
-                }
-            ],
-            "created_at": "2023-04-23T14:12:56.980Z",
-            "updated_at": "2023-04-23T14:20:55.990Z",
+            "created_at": "2023-04-25T05:06:50.568Z",
+            "updated_at": "2023-04-25T05:08:13.855Z",
             "tags": {
-                "cancellation_reason_id": "002"
+                "cancellation_reason_id": "005"
             }
         }
     }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/search.json
@@ -5,9 +5,9 @@
         "city": "std:011",
         "action": "search",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "lBnMNi_hNJehc7rvzLgcR",
-        "timestamp": "2023-04-23T14:08:40.533Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "qGd-H_ihfUO6j005qA-M8",
+        "timestamp": "2023-04-25T05:00:11.449Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "ttl": "PT30S"

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/select.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "select",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "h_i8nrFJDGuQ4al8OKeZB",
-        "timestamp": "2023-04-23T14:11:17.178Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "KPqPoKoaTmf-MYRUOL_Hz",
+        "timestamp": "2023-04-25T05:03:07.282Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -31,7 +30,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "location_id": "L1",
                     "quantity": {
                         "count": 2

--- a/logs/Rapidor/rapidor_own_seller_app/flow_2/select_non_serviceable.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_2/select_non_serviceable.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "select",
         "core_version": "2.0.0",
-        "transaction_id": "06dBlqeLGbUkJ43uTdJnc",
-        "message_id": "9-xafRgkzzyAMIoAk7R8d",
-        "timestamp": "2023-04-23T14:10:04.215Z",
+        "transaction_id": "hGz6j-eAHGzKlhFT-h7qA",
+        "message_id": "mn78REflGj6PCghB2Cvv9",
+        "timestamp": "2023-04-25T05:01:54.112Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -31,7 +30,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "location_id": "L1",
                     "quantity": {
                         "count": 2

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "confirm",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "5s3wWXF9DFlbgwNqiBtEU",
-        "timestamp": "2023-04-23T14:33:06.421Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "vCxRbKboUuGLQp0KFMLyM",
+        "timestamp": "2023-04-25T05:14:37.795Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -28,8 +28,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -58,7 +58,7 @@
                     "tracking": false
                 }
             ],
-            "id": "RAP-0000353",
+            "id": "RAP-0000362",
             "state": "Created",
             "provider": {
                 "id": "abadfoodslive",
@@ -73,7 +73,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -85,8 +85,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "J0jCmQnDnIvCtiPS1W_xP",
-                    "amount": "380.80"
+                    "transaction_id": "hC4NHcIKNAav-pRM8FEwb",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
@@ -99,10 +99,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -117,7 +117,7 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 0
@@ -125,6 +125,7 @@
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -137,12 +138,12 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
-            "created_at": "2023-04-23T14:33:06.428Z",
-            "updated_at": "2023-04-23T14:33:06.428Z"
+            "created_at": "2023-04-25T05:14:37.800Z",
+            "updated_at": "2023-04-25T05:14:37.800Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/init.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "init",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "RUqTQis9ktiOL_eXpaG7S",
-        "timestamp": "2023-04-23T14:32:20.000Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "nyte13BGesbUm_4Uqn4eJ",
+        "timestamp": "2023-04-25T05:13:52.000Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -52,7 +52,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -68,8 +68,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z",
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z",
                 "tax_number": "07AABCB2115P1ZR"
             }
         }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_confirm",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "5s3wWXF9DFlbgwNqiBtEU",
-        "timestamp": "2023-04-23T14:33:07.149Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "vCxRbKboUuGLQp0KFMLyM",
+        "timestamp": "2023-04-25T05:14:38.655Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,7 +16,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000353",
+            "id": "RAP-0000362",
             "provider": {
                 "id": "abadfoodslive",
                 "locations": [
@@ -31,7 +31,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -47,8 +47,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -68,14 +68,14 @@
                                 "images": [
                                     "https://www.rapidor.co/wp-content/uploads/2023/02/Logo.svg"
                                 ],
-                                "name": "ABAD FOODS"
+                                "name": "Abad Foods"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:33:07.000Z",
-                                "end": "2023-04-23T16:33:07.000Z"
+                                "start": "2023-04-25T05:14:38.000Z",
+                                "end": "2023-04-25T07:14:38.000Z"
                             }
                         },
                         "contact": {
@@ -97,8 +97,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:33:07.000Z",
-                                "end": "2023-04-25T16:33:07.000Z"
+                                "start": "2023-04-27T05:14:38.000Z",
+                                "end": "2023-04-27T07:14:38.000Z"
                             }
                         },
                         "contact": {
@@ -115,10 +115,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -133,11 +133,12 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -147,7 +148,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
@@ -159,21 +160,15 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "J0jCmQnDnIvCtiPS1W_xP",
-                    "amount": "380.80"
+                    "transaction_id": "hC4NHcIKNAav-pRM8FEwb",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
             },
             "state": "Created",
-            "documents": [
-                {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000353.pdf?v=1682260389",
-                    "label": "Order Note"
-                }
-            ],
-            "created_at": "2023-04-23T14:33:06.428Z",
-            "updated_at": "2023-04-23T14:33:07.149Z"
+            "created_at": "2023-04-25T05:14:37.800Z",
+            "updated_at": "2023-04-25T05:14:38.655Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_init.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_init",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "RUqTQis9ktiOL_eXpaG7S",
-        "timestamp": "2023-04-23T14:32:22.342Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "nyte13BGesbUm_4Uqn4eJ",
+        "timestamp": "2023-04-25T05:13:52.956Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -27,7 +27,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -43,8 +43,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -78,10 +78,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -96,11 +96,12 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -110,7 +111,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_search.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_search",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "TCw4BXc_85Mshq5AotbFK",
-        "timestamp": "2023-04-23T14:27:47.975Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "GedBQ5HolnRTQg7dlYaxF",
+        "timestamp": "2023-04-25T05:10:27.666Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -30,7 +30,7 @@
                 {
                     "id": "abadfoodslive",
                     "descriptor": {
-                        "name": "ABAD FOODS",
+                        "name": "Abad Foods",
                         "code": "abadfoodslive",
                         "short_desc": "PlaceOrder",
                         "long_desc": "PlaceOrder",
@@ -44,8 +44,8 @@
                         {
                             "id": "L1",
                             "area_code": "560001",
-                            "gps": "12.971600,77.594600",
-                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
+                            "gps": "12.998115,77.629250",
+                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
                             "city": {
                                 "name": "Bangalore",
                                 "code": "std:080"
@@ -55,7 +55,7 @@
                                 "code": "KA"
                             },
                             "country": {
-                                "name": "INDIA",
+                                "name": "India",
                                 "code": "IND"
                             }
                         }
@@ -112,7 +112,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",
@@ -162,8 +162,8 @@
                                         "return_within": "P7D",
                                         "fulfillment_managed_by": "seller",
                                         "return_location": {
-                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
-                                            "gps": "12.971600,77.594600"
+                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
+                                            "gps": "12.998115,77.629250"
                                         }
                                     }
                                 }
@@ -219,7 +219,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",
@@ -269,8 +269,8 @@
                                         "return_within": "P7D",
                                         "fulfillment_managed_by": "seller",
                                         "return_location": {
-                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd, Koranmangala",
-                                            "gps": "12.971600,77.594600"
+                                            "address": "No B 79, Mahadevpura, 7th Cross, Masjid Rd",
+                                            "gps": "12.998115,77.629250"
                                         }
                                     }
                                 }
@@ -296,7 +296,7 @@
                                 },
                                 {
                                     "code": "seller_id_no",
-                                    "value": "07AAGFF2194N1Z4"
+                                    "value": "29AAFCA6821M1ZB"
                                 }
                             ]
                         },

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_select.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_select",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "0NZv2xPrn6DvRFL85Cic3",
-        "timestamp": "2023-04-23T14:31:25.545Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "bc8W26UDrs4JMd_4rVjBV",
+        "timestamp": "2023-04-25T05:12:41.731Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -21,7 +21,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1"
                 }
             ],
@@ -42,43 +42,56 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "0.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 0
+                            "count": 2
                         },
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             },
                             "quantity": {
                                 "available": {
-                                    "count": "0"
+                                    "count": "2"
                                 },
                                 "maximum": {
-                                    "count": "0"
+                                    "count": "2"
                                 }
                             }
+                        }
+                    },
+                    {
+                        "title": "tax",
+                        "@ondc/org/item_id": "ITM05550",
+                        "@ondc/org/title_type": "tax",
+                        "price": {
+                            "currency": "INR",
+                            "value": "81.60"
+                        }
+                    },
+                    {
+                        "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
+                        "@ondc/org/title_type": "delivery",
+                        "price": {
+                            "currency": "INR",
+                            "value": "0.00"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "0.00"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             }
         }
-    },
-    "error": {
-        "type": "DOMAIN-ERROR",
-        "code": "40002",
-        "message": "Item is not in stock"
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_select_quantity_error.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_select_quantity_error.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "on_select",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "3aQXyCXDpBosmFZBDLwDn",
-        "timestamp": "2023-04-23T14:29:56.936Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "TWY1aDKMzyOMr9CdIU6N8",
+        "timestamp": "2023-04-25T05:11:47.121Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -78,10 +77,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -90,10 +89,10 @@
                             },
                             "quantity": {
                                 "available": {
-                                    "count": "1"
+                                    "count": "2"
                                 },
                                 "maximum": {
-                                    "count": "1"
+                                    "count": "2"
                                 }
                             }
                         }
@@ -104,13 +103,13 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     }
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_accepted.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_accepted.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "rDP_CtMCS-BeqzpBgpQ61",
-        "timestamp": "2023-04-23T14:35:08.231Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "zYC5oeunqi6EhV-UNiyUk",
+        "timestamp": "2023-04-25T05:15:43.371Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -15,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000353",
+            "id": "RAP-0000362",
             "state": "Accepted",
             "provider": {
                 "id": "abadfoodslive",
@@ -30,7 +30,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -46,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -68,12 +68,12 @@
                                 ],
                                 "name": "PlaceOrder"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:33:07.000Z",
-                                "end": "2023-04-23T16:33:07.000Z"
+                                "start": "2023-04-25T05:14:38.000Z",
+                                "end": "2023-04-25T07:14:38.000Z"
                             }
                         },
                         "contact": {
@@ -95,8 +95,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:33:07.000Z",
-                                "end": "2023-04-25T16:33:07.000Z"
+                                "start": "2023-04-27T05:14:38.000Z",
+                                "end": "2023-04-27T07:14:38.000Z"
                             }
                         },
                         "contact": {
@@ -113,8 +113,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "J0jCmQnDnIvCtiPS1W_xP",
-                    "amount": "380.80"
+                    "transaction_id": "hC4NHcIKNAav-pRM8FEwb",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -127,10 +127,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -145,11 +145,12 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -159,18 +160,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000353.pdf?v=1682260389",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000362.pdf?v=1682399743",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T14:33:06.428Z",
-            "updated_at": "2023-04-23T14:35:08.216Z"
+            "created_at": "2023-04-25T05:14:37.800Z",
+            "updated_at": "2023-04-25T05:15:41.991Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_delivered.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_delivered.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "mZFO6SiyXY_79eXRvD5Wb",
-        "timestamp": "2023-04-23T14:36:58.435Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "yMtwyw59tBIHUXesD4rij",
+        "timestamp": "2023-04-25T05:16:57.138Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -15,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000353",
+            "id": "RAP-0000362",
             "state": "Completed",
             "provider": {
                 "id": "abadfoodslive",
@@ -30,7 +30,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -46,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -68,14 +68,14 @@
                                 ],
                                 "name": "PlaceOrder"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:33:07.000Z",
-                                "end": "2023-04-23T16:33:07.000Z"
+                                "start": "2023-04-25T05:14:38.000Z",
+                                "end": "2023-04-25T07:14:38.000Z"
                             },
-                            "timestamp": "2023-04-23T14:36:22.000Z"
+                            "timestamp": "2023-04-25T05:16:22.000Z"
                         },
                         "contact": {
                             "phone": "9072377660"
@@ -96,10 +96,10 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:33:07.000Z",
-                                "end": "2023-04-25T16:33:07.000Z"
+                                "start": "2023-04-27T05:14:38.000Z",
+                                "end": "2023-04-27T07:14:38.000Z"
                             },
-                            "timestamp": "2023-04-23T14:36:58.426Z"
+                            "timestamp": "2023-04-25T05:16:57.128Z"
                         },
                         "contact": {
                             "phone": "7600554570"
@@ -115,8 +115,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "J0jCmQnDnIvCtiPS1W_xP",
-                    "amount": "380.80"
+                    "transaction_id": "hC4NHcIKNAav-pRM8FEwb",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -129,10 +129,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -147,11 +147,12 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -161,18 +162,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000353.pdf?v=1682260389",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000362.pdf?v=1682399743",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T14:33:06.428Z",
-            "updated_at": "2023-04-23T14:36:58.426Z"
+            "created_at": "2023-04-25T05:14:37.800Z",
+            "updated_at": "2023-04-25T05:16:57.128Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_out_for_delivery.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/on_status_out_for_delivery.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "aIPZuyVes6UK5jVZ_RFgk",
-        "timestamp": "2023-04-23T14:36:22.489Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "21APl1SXkhupsh-wVnvKs",
+        "timestamp": "2023-04-25T05:16:22.310Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -15,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000353",
+            "id": "RAP-0000362",
             "state": "In-progress",
             "provider": {
                 "id": "abadfoodslive",
@@ -30,7 +30,7 @@
                     "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],
@@ -46,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T14:32:20.000Z",
-                "updated_at": "2023-04-23T14:32:20.000Z"
+                "created_at": "2023-04-25T05:13:52.000Z",
+                "updated_at": "2023-04-25T05:13:52.000Z"
             },
             "fulfillments": [
                 {
@@ -68,14 +68,14 @@
                                 ],
                                 "name": "PlaceOrder"
                             },
-                            "gps": "12.971600,77.594600"
+                            "gps": "12.998115,77.629250"
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T14:33:07.000Z",
-                                "end": "2023-04-23T16:33:07.000Z"
+                                "start": "2023-04-25T05:14:38.000Z",
+                                "end": "2023-04-25T07:14:38.000Z"
                             },
-                            "timestamp": "2023-04-23T14:36:22.051Z"
+                            "timestamp": "2023-04-25T05:16:22.302Z"
                         },
                         "contact": {
                             "phone": "9072377660"
@@ -96,8 +96,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T14:33:07.000Z",
-                                "end": "2023-04-25T16:33:07.000Z"
+                                "start": "2023-04-27T05:14:38.000Z",
+                                "end": "2023-04-27T07:14:38.000Z"
                             }
                         },
                         "contact": {
@@ -114,8 +114,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "J0jCmQnDnIvCtiPS1W_xP",
-                    "amount": "380.80"
+                    "transaction_id": "hC4NHcIKNAav-pRM8FEwb",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -128,10 +128,10 @@
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "340.00"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
-                            "count": 1
+                            "count": 2
                         },
                         "item": {
                             "price": {
@@ -146,11 +146,12 @@
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "40.80"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -160,18 +161,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "380.80"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000353.pdf?v=1682260389",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000362.pdf?v=1682399743",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T14:33:06.428Z",
-            "updated_at": "2023-04-23T14:36:22.051Z"
+            "created_at": "2023-04-25T05:14:37.800Z",
+            "updated_at": "2023-04-25T05:16:22.302Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/search.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "search",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "TCw4BXc_85Mshq5AotbFK",
-        "timestamp": "2023-04-23T14:27:46.289Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "GedBQ5HolnRTQg7dlYaxF",
+        "timestamp": "2023-04-25T05:10:27.269Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "ttl": "PT30S"

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/select.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "select",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "0NZv2xPrn6DvRFL85Cic3",
-        "timestamp": "2023-04-23T14:31:24.711Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "bc8W26UDrs4JMd_4rVjBV",
+        "timestamp": "2023-04-25T05:12:41.255Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -30,7 +30,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "location_id": "L1",
                     "quantity": {
                         "count": 2

--- a/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/select_quantity_error.json
+++ b/logs/Rapidor/rapidor_own_seller_app/flow_4_without_return/select_quantity_error.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "select",
         "core_version": "2.0.0",
-        "transaction_id": "e-2P4dGw0vqZfcr4aRr06",
-        "message_id": "3aQXyCXDpBosmFZBDLwDn",
-        "timestamp": "2023-04-23T14:29:54.506Z",
+        "transaction_id": "sfCrRDvpjxNKNLP-eeiHO",
+        "message_id": "TWY1aDKMzyOMr9CdIU6N8",
+        "timestamp": "2023-04-25T05:11:46.268Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -33,14 +33,14 @@
                     "id": "ITM05341",
                     "location_id": "L1",
                     "quantity": {
-                        "count": 2
+                        "count": 1
                     }
                 },
                 {
                     "id": "ITM05550",
                     "location_id": "L1",
                     "quantity": {
-                        "count": 1
+                        "count": 2
                     }
                 }
             ],

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "confirm",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "Nzv48Af4g8jg3Pwb_S0FN",
-        "timestamp": "2023-04-23T13:57:26.281Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "CFmmdxNXNhGeK7nrFu7Q7",
+        "timestamp": "2023-04-25T04:15:26.821Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -28,8 +28,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -58,7 +58,7 @@
                     "tracking": false
                 }
             ],
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "state": "Created",
             "provider": {
                 "id": "abadfoodslive",
@@ -70,7 +70,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -85,8 +85,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
@@ -94,12 +94,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -107,17 +107,17 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 0
@@ -125,6 +125,7 @@
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -137,12 +138,12 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T13:57:26.286Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:15:26.825Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/init.json
@@ -1,3 +1,4 @@
+	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -5,9 +6,9 @@
         "city": "std:080",
         "action": "init",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "wYkJQP6APH90leXET6-3t",
-        "timestamp": "2023-04-23T13:56:43.000Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "fd06JKWOrbRxa3NuR3GOK",
+        "timestamp": "2023-04-25T04:14:28.000Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -49,7 +50,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -68,8 +69,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z",
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z",
                 "tax_number": "07AABCB2115P1ZR"
             }
         }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_confirm.json
@@ -1,3 +1,4 @@
+	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -5,9 +6,9 @@
         "city": "std:080",
         "action": "on_confirm",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "Nzv48Af4g8jg3Pwb_S0FN",
-        "timestamp": "2023-04-23T13:57:26.863Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "CFmmdxNXNhGeK7nrFu7Q7",
+        "timestamp": "2023-04-25T04:15:27.138Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,7 +17,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "provider": {
                 "id": "abadfoodslive",
                 "locations": [
@@ -28,7 +29,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -47,8 +48,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -74,8 +75,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T13:57:26.000Z",
-                                "end": "2023-04-23T15:57:26.000Z"
+                                "start": "2023-04-25T04:15:27.000Z",
+                                "end": "2023-04-25T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -97,8 +98,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T13:57:26.000Z",
-                                "end": "2023-04-25T15:57:26.000Z"
+                                "start": "2023-04-27T04:15:27.000Z",
+                                "end": "2023-04-27T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -110,12 +111,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -123,21 +124,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -147,7 +149,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
@@ -159,21 +161,15 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0"
             },
             "state": "Created",
-            "documents": [
-                {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000351.pdf?v=1682258248",
-                    "label": "Order Note"
-                }
-            ],
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T13:57:26.863Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:15:27.138Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_init.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_init.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_init",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "wYkJQP6APH90leXET6-3t",
-        "timestamp": "2023-04-23T13:56:44.315Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "fd06JKWOrbRxa3NuR3GOK",
+        "timestamp": "2023-04-25T04:14:29.459Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -24,7 +24,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -43,8 +43,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -73,12 +73,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -86,21 +86,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -110,7 +111,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_search.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_search",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "01m17hQtyHt19ZvUVKADF",
-        "timestamp": "2023-04-23T13:55:08.170Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "qm6hUTb3q9mofGsQWH-Y2",
+        "timestamp": "2023-04-25T04:12:23.944Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -102,7 +102,7 @@
                                 "unitized": {
                                     "measure": {
                                         "unit": "Units",
-                                        "value": "100"
+                                        "value": "0"
                                     }
                                 }
                             },
@@ -112,7 +112,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",
@@ -219,7 +219,7 @@
                                     "list": [
                                         {
                                             "code": "time_to_ship",
-                                            "value": "P2D"
+                                            "value": "P1D"
                                         },
                                         {
                                             "code": "tax_rate",

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_select.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "on_select",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "HTDjY2Gnf8hYKPTVjaova",
-        "timestamp": "2023-04-23T13:55:59.860Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "iXGWrZ1FuLnqnPbl45EYs",
+        "timestamp": "2023-04-25T04:13:31.249Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -22,7 +21,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1"
                 }
             ],
@@ -43,12 +42,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -56,7 +55,7 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             },
                             "quantity": {
                                 "available": {
@@ -70,15 +69,16 @@
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -88,7 +88,7 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_after_acceptance.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_after_acceptance.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "awOJooGJIM-MPsf5WVB1X",
-        "timestamp": "2023-04-23T14:00:16.788Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "ofkixj6gtESfKofOjqWyc",
+        "timestamp": "2023-04-25T04:17:49.166Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -15,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "state": "Accepted",
             "provider": {
                 "id": "abadfoodslive",
@@ -27,7 +27,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -46,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -72,8 +72,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T13:57:26.000Z",
-                                "end": "2023-04-23T15:57:26.000Z"
+                                "start": "2023-04-25T04:15:27.000Z",
+                                "end": "2023-04-25T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -95,8 +95,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T13:57:26.000Z",
-                                "end": "2023-04-25T15:57:26.000Z"
+                                "start": "2023-04-27T04:15:27.000Z",
+                                "end": "2023-04-27T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -113,8 +113,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -122,12 +122,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -135,21 +135,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -159,18 +160,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000351.pdf?v=1682258248",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000359.pdf?v=1682396269",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T14:00:16.758Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:17:48.051Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_after_confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_after_confirm.json
@@ -1,3 +1,4 @@
+	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -5,9 +6,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "OWL68VIcS-BbmkhwNECkd",
-        "timestamp": "2023-04-23T13:58:31.942Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "jyfpIUSAQHxbW8nAk5nMW",
+        "timestamp": "2023-04-25T04:16:27.652Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -16,7 +17,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "state": "Created",
             "provider": {
                 "id": "abadfoodslive",
@@ -28,7 +29,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -47,8 +48,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -73,8 +74,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T13:57:26.000Z",
-                                "end": "2023-04-23T15:57:26.000Z"
+                                "start": "2023-04-25T04:15:27.000Z",
+                                "end": "2023-04-25T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -96,8 +97,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T13:57:26.000Z",
-                                "end": "2023-04-25T15:57:26.000Z"
+                                "start": "2023-04-27T04:15:27.000Z",
+                                "end": "2023-04-27T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -114,8 +115,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -123,12 +124,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -136,21 +137,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -160,18 +162,12 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
-            "documents": [
-                {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000351.pdf?v=1682258248",
-                    "label": "Order Note"
-                }
-            ],
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T13:57:28.919Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:15:27.606Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_delivered.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_delivered.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "3kASIGeW6y1_yFcw0mdQL",
-        "timestamp": "2023-04-23T14:02:22.040Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "05gBMqrHkiOTiK5-Rf9Fj",
+        "timestamp": "2023-04-25T04:21:13.807Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -15,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "state": "Completed",
             "provider": {
                 "id": "abadfoodslive",
@@ -27,7 +27,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -46,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -72,10 +72,10 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T13:57:26.000Z",
-                                "end": "2023-04-23T15:57:26.000Z"
+                                "start": "2023-04-25T04:15:27.000Z",
+                                "end": "2023-04-25T06:15:27.000Z"
                             },
-                            "timestamp": "2023-04-23T14:01:26.000Z"
+                            "timestamp": "2023-04-25T04:18:30.000Z"
                         },
                         "contact": {
                             "phone": "9072377660"
@@ -96,10 +96,10 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T13:57:26.000Z",
-                                "end": "2023-04-25T15:57:26.000Z"
+                                "start": "2023-04-27T04:15:27.000Z",
+                                "end": "2023-04-27T06:15:27.000Z"
                             },
-                            "timestamp": "2023-04-23T14:02:20.687Z"
+                            "timestamp": "2023-04-25T04:21:13.800Z"
                         },
                         "contact": {
                             "phone": "7600554570"
@@ -115,8 +115,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -124,12 +124,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -137,21 +137,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -161,18 +162,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000351.pdf?v=1682258248",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000359.pdf?v=1682396269",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T14:02:20.687Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:21:13.800Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_out_for_delivery.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/on_status_out_for_delivery.json
@@ -1,4 +1,3 @@
-	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -6,9 +5,9 @@
         "city": "std:080",
         "action": "on_status",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "UBMWogfFvOWlUCWkyyyk6",
-        "timestamp": "2023-04-23T14:01:26.483Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "WhJuhdhIlO5fLmfc6CGdi",
+        "timestamp": "2023-04-25T04:18:30.518Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
         "bpp_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
@@ -16,7 +15,7 @@
     },
     "message": {
         "order": {
-            "id": "RAP-0000351",
+            "id": "RAP-0000359",
             "state": "In-progress",
             "provider": {
                 "id": "abadfoodslive",
@@ -28,7 +27,7 @@
             },
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "fulfillment_id": "F1",
                     "quantity": {
                         "count": 2
@@ -47,8 +46,8 @@
                     "country": "IND"
                 },
                 "phone": "7600554570",
-                "created_at": "2023-04-23T13:56:43.000Z",
-                "updated_at": "2023-04-23T13:56:43.000Z"
+                "created_at": "2023-04-25T04:14:28.000Z",
+                "updated_at": "2023-04-25T04:14:28.000Z"
             },
             "fulfillments": [
                 {
@@ -73,10 +72,10 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-23T13:57:26.000Z",
-                                "end": "2023-04-23T15:57:26.000Z"
+                                "start": "2023-04-25T04:15:27.000Z",
+                                "end": "2023-04-25T06:15:27.000Z"
                             },
-                            "timestamp": "2023-04-23T14:01:26.473Z"
+                            "timestamp": "2023-04-25T04:18:30.510Z"
                         },
                         "contact": {
                             "phone": "9072377660"
@@ -97,8 +96,8 @@
                         },
                         "time": {
                             "range": {
-                                "start": "2023-04-25T13:57:26.000Z",
-                                "end": "2023-04-25T15:57:26.000Z"
+                                "start": "2023-04-27T04:15:27.000Z",
+                                "end": "2023-04-27T06:15:27.000Z"
                             }
                         },
                         "contact": {
@@ -115,8 +114,8 @@
                 "collected_by": "BAP",
                 "params": {
                     "currency": "INR",
-                    "transaction_id": "_Xl_tYHhT7tF80e6tGX_8",
-                    "amount": "802.39"
+                    "transaction_id": "zF1eQrSnEYb5MGRaTpdwP",
+                    "amount": "761.60"
                 },
                 "@ondc/org/buyer_app_finder_fee_type": "percent",
                 "@ondc/org/buyer_app_finder_fee_amount": "0.0"
@@ -124,12 +123,12 @@
             "quote": {
                 "breakup": [
                     {
-                        "title": "CS CHICKEN CUTLET 15X500GMS NET RTF ASSRTD",
-                        "@ondc/org/item_id": "ITM05341",
+                        "title": "CHICKEN CUTLET 6X1KG NET RTF ASSRTD",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "item",
                         "price": {
                             "currency": "INR",
-                            "value": "716.42"
+                            "value": "680.00"
                         },
                         "@ondc/org/item_quantity": {
                             "count": 2
@@ -137,21 +136,22 @@
                         "item": {
                             "price": {
                                 "currency": "INR",
-                                "value": "358.21"
+                                "value": "340.00"
                             }
                         }
                     },
                     {
                         "title": "tax",
-                        "@ondc/org/item_id": "ITM05341",
+                        "@ondc/org/item_id": "ITM05550",
                         "@ondc/org/title_type": "tax",
                         "price": {
                             "currency": "INR",
-                            "value": "85.97"
+                            "value": "81.60"
                         }
                     },
                     {
                         "title": "Delivery Charge",
+                        "@ondc/org/item_id": "F1",
                         "@ondc/org/title_type": "delivery",
                         "price": {
                             "currency": "INR",
@@ -161,18 +161,18 @@
                 ],
                 "price": {
                     "currency": "INR",
-                    "value": "802.39"
+                    "value": "761.60"
                 },
                 "ttl": "P2D"
             },
             "documents": [
                 {
-                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000351.pdf?v=1682258248",
-                    "label": "Order Note"
+                    "url": "https://ondcpreprodb2b.rapidor.co/static/pdf/RAP-0000359.pdf?v=1682396269",
+                    "label": "Invoice"
                 }
             ],
-            "created_at": "2023-04-23T13:57:26.286Z",
-            "updated_at": "2023-04-23T14:01:26.473Z"
+            "created_at": "2023-04-25T04:15:26.825Z",
+            "updated_at": "2023-04-25T04:18:30.510Z"
         }
     }
 }

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/search.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/search.json
@@ -1,3 +1,4 @@
+	
 {
     "context": {
         "domain": "ONDC:RET10",
@@ -5,9 +6,9 @@
         "city": "std:080",
         "action": "search",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "01m17hQtyHt19ZvUVKADF",
-        "timestamp": "2023-04-23T13:55:07.189Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "qm6hUTb3q9mofGsQWH-Y2",
+        "timestamp": "2023-04-25T04:12:23.351Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "ttl": "PT30S"

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/select.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/select.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "select",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "HTDjY2Gnf8hYKPTVjaova",
-        "timestamp": "2023-04-23T13:55:58.603Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "iXGWrZ1FuLnqnPbl45EYs",
+        "timestamp": "2023-04-25T04:13:29.990Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -30,7 +30,7 @@
             ],
             "items": [
                 {
-                    "id": "ITM05341",
+                    "id": "ITM05550",
                     "location_id": "L1",
                     "quantity": {
                         "count": 2

--- a/logs/Rapidor/rapidor_own_seller_app/normal_flow/status_after_confirm.json
+++ b/logs/Rapidor/rapidor_own_seller_app/normal_flow/status_after_confirm.json
@@ -5,9 +5,9 @@
         "city": "std:080",
         "action": "status",
         "core_version": "2.0.0",
-        "transaction_id": "eo5z8pr5GOO1kXx53XA1_",
-        "message_id": "OWL68VIcS-BbmkhwNECkd",
-        "timestamp": "2023-04-23T13:58:31.481Z",
+        "transaction_id": "9P4Cia0Pgtsyy9S3VEEfQ",
+        "message_id": "jyfpIUSAQHxbW8nAk5nMW",
+        "timestamp": "2023-04-25T04:16:27.463Z",
         "bap_id": "ondcpreprodb2b.rapidor.co",
         "bap_uri": "https://ondcpreprodb2b.rapidor.co/v1/ondc/buyer",
         "bpp_id": "ondcpreprodb2b.rapidor.co",
@@ -15,6 +15,6 @@
         "ttl": "PT30S"
     },
     "message": {
-        "order_id": "RAP-0000351"
+        "order_id": "RAP-0000359"
     }
 }


### PR DESCRIPTION
At present, Rapidor orders moves from Accepted to Out-for-delivery. There is NO intermediate state called Picked-up. For us, Picked-up is same as Out-for-delivery. 

All other changes are done and pushed.